### PR TITLE
fix: docker compose --env-file .env.prod 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,6 @@ jobs:
             set -e
             cd ~/nestjs-dhyunbot
             git pull origin main
-            docker compose -f docker-compose.prod.yml up -d --build
-            docker compose -f docker-compose.prod.yml exec api npx typeorm migration:run -d dist/apps/api/src/data-source.js
+            docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build
+            docker compose --env-file .env.prod -f docker-compose.prod.yml exec api npx typeorm migration:run -d dist/apps/api/src/data-source.js
             docker image prune -f


### PR DESCRIPTION
## Summary
- docker compose 명령에 `--env-file .env.prod` 플래그 추가
- YAML 파일 내 `${REDIS_PASSWORD}`, `${DATABASE_USER}` 등 변수가 치환되지 않아 Redis 헬스체크 실패하던 문제 수정

## Test plan
- [ ] 배포 시 Redis/PostgreSQL 컨테이너 정상 시작 확인
- [ ] 마이그레이션 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)