### PR TITLE
develop → main 통합 (접두사 중복 검증 외)

### DIFF
--- a/apps/api/src/status-prefix/application/status-prefix-config.service.ts
+++ b/apps/api/src/status-prefix/application/status-prefix-config.service.ts
@@ -1,5 +1,5 @@
 import { InjectDiscordClient } from '@discord-nestjs/core';
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import {
   ActionRowBuilder,
   ButtonBuilder,
@@ -52,6 +52,18 @@ export class StatusPrefixConfigService {
    *   4. 전송된 messageId를 DB에 저장
    */
   async saveConfig(guildId: string, dto: StatusPrefixConfigSaveDto): Promise<StatusPrefixConfig> {
+    // 0. PREFIX 타입 버튼 간 접두사 중복 검증
+    const prefixButtons = dto.buttons.filter((b) => b.type === StatusPrefixButtonType.PREFIX);
+    const seen = new Set<string>();
+    for (const btn of prefixButtons) {
+      const trimmed = btn.prefix?.trim();
+      if (!trimmed) continue;
+      if (seen.has(trimmed)) {
+        throw new BadRequestException(`접두사 "${trimmed}"이(가) 중복됩니다.`);
+      }
+      seen.add(trimmed);
+    }
+
     // 1. DB upsert
     const config = await this.configRepo.upsert(guildId, dto);
 

--- a/apps/web/app/settings/guild/[guildId]/status-prefix/page.tsx
+++ b/apps/web/app/settings/guild/[guildId]/status-prefix/page.tsx
@@ -161,6 +161,7 @@ export default function StatusPrefixSettingsPage() {
     }
     if (config.enabled) {
       const sorted = [...config.buttons].sort((a, b) => a.sortOrder - b.sortOrder);
+      const seenPrefixes = new Set<string>();
       for (let i = 0; i < sorted.length; i++) {
         const btn = sorted[i];
         if (!btn.label.trim()) {
@@ -170,6 +171,14 @@ export default function StatusPrefixSettingsPage() {
         if (btn.type === 'PREFIX' && !btn.prefix?.trim()) {
           errors.push(`버튼 #${i + 1}의 접두사 텍스트를 입력해주세요.`);
           break;
+        }
+        if (btn.type === 'PREFIX' && btn.prefix) {
+          const trimmed = btn.prefix.trim();
+          if (seenPrefixes.has(trimmed)) {
+            errors.push(`접두사 "${trimmed}"이(가) 중복됩니다.`);
+            break;
+          }
+          seenPrefixes.add(trimmed);
         }
       }
     }


### PR DESCRIPTION
## Summary
- feat: 상태설정 접두사(prefix) 중복 검증 추가 (프론트엔드 + 백엔드)
- feat: 고정메세지(Sticky Message) 기능 추가
- fix: docker compose 환경 변수 및 배포 스크립트 수정
- 기타 다수 기능 추가 및 버그 수정 (자동방, 신입관리, 음성분석 등)

## Test plan
- [ ] 상태설정 페이지에서 동일한 접두사를 가진 버튼 2개 추가 후 저장 시 에러 메시지 표시 확인
- [ ] 백엔드 API 직접 호출 시 중복 접두사에 대해 400 응답 확인
- [ ] 고정메세지 CRUD 및 Discord 메시지 동기화 확인
- [ ] Docker Compose 개발/운영 환경 정상 기동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)