### PR TITLE
fix: 고정메세지 자동 하단 이동 버그 수정

### DIFF
--- a/apps/api/src/event/discord-events.module.ts
+++ b/apps/api/src/event/discord-events.module.ts
@@ -9,6 +9,7 @@ import { StatusPrefixModule } from '../status-prefix/status-prefix.module';
 import { StickyMessageModule } from '../sticky-message/sticky-message.module';
 import { ChannelStateHandler } from './channel/channel-state.handler';
 import { NewbieInteractionHandler } from './newbie/newbie-interaction.handler';
+import { StickyMessageHandler } from './sticky-message/sticky-message.handler';
 import { VoiceAloneHandler } from './voice/voice-alone.handler';
 import { VoiceJoinHandler } from './voice/voice-join.handler';
 import { VoiceLeaveHandler } from './voice/voice-leave.handler';
@@ -35,6 +36,7 @@ import { VoiceStateDispatcher } from './voice/voice-state.dispatcher';
     MicToggleHandler,
     VoiceAloneHandler,
     NewbieInteractionHandler,
+    StickyMessageHandler,
   ],
 })
 export class DiscordEventsModule {}

--- a/apps/api/src/event/sticky-message/sticky-message.handler.ts
+++ b/apps/api/src/event/sticky-message/sticky-message.handler.ts
@@ -1,0 +1,63 @@
+import { On } from '@discord-nestjs/core';
+import { Injectable, Logger } from '@nestjs/common';
+import { Message } from 'discord.js';
+
+import { StickyMessageRefreshService } from '../../sticky-message/application/sticky-message-refresh.service';
+import { StickyMessageConfigRepository } from '../../sticky-message/infrastructure/sticky-message-config.repository';
+import { StickyMessageRedisRepository } from '../../sticky-message/infrastructure/sticky-message-redis.repository';
+
+@Injectable()
+export class StickyMessageHandler {
+  private readonly logger = new Logger(StickyMessageHandler.name);
+  private readonly timers = new Map<string, NodeJS.Timeout>();
+
+  constructor(
+    private readonly redisRepo: StickyMessageRedisRepository,
+    private readonly configRepo: StickyMessageConfigRepository,
+    private readonly refreshService: StickyMessageRefreshService,
+  ) {}
+
+  @On('messageCreate')
+  async handleMessageCreate(message: Message): Promise<void> {
+    try {
+      if (message.author.bot) return;
+
+      const guildId = message.guildId;
+      if (!guildId) return;
+
+      const channelId = message.channelId;
+
+      let configs = await this.redisRepo.getConfig(guildId);
+      if (!configs) {
+        configs = await this.configRepo.findByGuildId(guildId);
+        await this.redisRepo.setConfig(guildId, configs);
+      }
+
+      const hasConfig = configs.some((c) => c.channelId === channelId && c.enabled);
+      if (!hasConfig) return;
+
+      const existing = this.timers.get(channelId);
+      if (existing) clearTimeout(existing);
+
+      const timer = setTimeout(() => {
+        this.timers.delete(channelId);
+        this.refreshService.refresh(guildId, channelId).catch((err: Error) => {
+          this.logger.error(
+            `[messageCreate] refresh failed: guild=${guildId} channel=${channelId}`,
+            err.stack,
+          );
+        });
+      }, 3000);
+      this.timers.set(channelId, timer);
+
+      this.redisRepo.setDebounce(channelId).catch((err: Error) => {
+        this.logger.warn(`[messageCreate] setDebounce failed: channel=${channelId}`, err.stack);
+      });
+    } catch (err) {
+      this.logger.error(
+        `[messageCreate] unhandled error: guild=${message.guildId} channel=${message.channelId}`,
+        (err as Error).stack,
+      );
+    }
+  }
+}

--- a/apps/api/src/sticky-message/sticky-message.module.ts
+++ b/apps/api/src/sticky-message/sticky-message.module.ts
@@ -9,7 +9,6 @@ import { StickyMessageDeleteCommand } from './command/sticky-message-delete.comm
 import { StickyMessageListCommand } from './command/sticky-message-list.command';
 import { StickyMessageRegisterCommand } from './command/sticky-message-register.command';
 import { StickyMessageConfig } from './domain/sticky-message-config.entity';
-import { StickyMessageGateway } from './gateway/sticky-message.gateway';
 import { StickyMessageConfigRepository } from './infrastructure/sticky-message-config.repository';
 import { StickyMessageRedisRepository } from './infrastructure/sticky-message-redis.repository';
 import { StickyMessageController } from './presentation/sticky-message.controller';
@@ -26,13 +25,13 @@ import { StickyMessageController } from './presentation/sticky-message.controlle
     StickyMessageRedisRepository,
     StickyMessageConfigService,
     StickyMessageRefreshService,
-    StickyMessageGateway,
     StickyMessageRegisterCommand,
     StickyMessageListCommand,
     StickyMessageDeleteCommand,
   ],
   exports: [
     StickyMessageConfigService,
+    StickyMessageRefreshService,
     StickyMessageConfigRepository,
     StickyMessageRedisRepository,
   ],

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  /* config options here */
+};
+
+export default nextConfig;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,9 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  /* config options here */
-  // Disable Turbopack and use webpack for monorepo compatibility
-  // Or set TURBOPACK_ROOT environment variable
-};
-
-export default nextConfig;


### PR DESCRIPTION
## Summary
- `StickyMessageGateway`의 `@On('messageCreate')` 핸들러가 `StickyMessageModule` 내부 provider로만 등록되어 `ExplorerService`가 이벤트를 탐색하지 못하던 버그 수정
- 기존 작동하는 핸들러 패턴(`DiscordEventsModule` providers 직접 등록)에 맞춰 `StickyMessageHandler`를 `event/sticky-message/` 하위에 생성 및 등록

## Test plan
- [ ] 고정메세지가 설정된 채널에서 메시지를 보낸 후 3초 뒤 고정메세지가 하단으로 이동하는지 확인
- [ ] 연속 메시지 전송 시 디바운스가 정상 작동하는지 확인
- [ ] 고정메세지 설정이 없는 채널에서는 동작하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)