### PR TITLE
fix: Dockerfile.prod next.config 참조 수정

### DIFF
--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -45,7 +45,7 @@ COPY --from=builder /workspace/libs/shared/package.json ./libs/shared/
 COPY --from=builder /workspace/apps/web/.next ./apps/web/.next
 COPY --from=builder /workspace/apps/web/public ./apps/web/public
 COPY --from=builder /workspace/apps/web/package.json ./apps/web/
-COPY --from=builder /workspace/apps/web/next.config.ts ./apps/web/
+COPY --from=builder /workspace/apps/web/next.config.mjs ./apps/web/
 
 WORKDIR /workspace/apps/web
 


### PR DESCRIPTION
## Summary
- Dockerfile.prod에서 `next.config.ts` → `next.config.mjs`로 참조 수정
- 이전 커밋(c896401)에서 next.config 파일 확장자를 변경했으나 Dockerfile 반영이 누락되어 Deploy to Lightsail 워크플로우가 실패하던 문제 해결

## Test plan
- [ ] Deploy to Lightsail GitHub Action이 정상 통과하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)