### PR TITLE
fix: 다른 봇 메시지 고정메세지 갱신 + 디바운스 1초 단축

### DIFF
--- a/apps/api/src/event/sticky-message/sticky-message.handler.ts
+++ b/apps/api/src/event/sticky-message/sticky-message.handler.ts
@@ -1,6 +1,6 @@
-import { On } from '@discord-nestjs/core';
+import { InjectDiscordClient, On } from '@discord-nestjs/core';
 import { Injectable, Logger } from '@nestjs/common';
-import { Message } from 'discord.js';
+import { Client, Message } from 'discord.js';
 
 import { StickyMessageRefreshService } from '../../sticky-message/application/sticky-message-refresh.service';
 import { StickyMessageConfigRepository } from '../../sticky-message/infrastructure/sticky-message-config.repository';
@@ -15,12 +15,14 @@ export class StickyMessageHandler {
     private readonly redisRepo: StickyMessageRedisRepository,
     private readonly configRepo: StickyMessageConfigRepository,
     private readonly refreshService: StickyMessageRefreshService,
+    @InjectDiscordClient() private readonly client: Client,
   ) {}
 
   @On('messageCreate')
   async handleMessageCreate(message: Message): Promise<void> {
     try {
-      if (message.author.bot) return;
+      // 자기 자신의 메시지만 무시 (다른 봇의 메시지는 갱신 트리거)
+      if (message.author.id === this.client.user?.id) return;
 
       const guildId = message.guildId;
       if (!guildId) return;
@@ -47,7 +49,7 @@ export class StickyMessageHandler {
             err.stack,
           );
         });
-      }, 3000);
+      }, 1000);
       this.timers.set(channelId, timer);
 
       this.redisRepo.setDebounce(channelId).catch((err: Error) => {

--- a/apps/api/src/sticky-message/infrastructure/sticky-message-redis.repository.ts
+++ b/apps/api/src/sticky-message/infrastructure/sticky-message-redis.repository.ts
@@ -8,8 +8,8 @@ import { StickyMessageKeys } from './sticky-message-cache.keys';
 const TTL = {
   /** 설정 캐시: 1시간 */
   CONFIG: 60 * 60,
-  /** 디바운스 타이머: 3초 */
-  DEBOUNCE: 3,
+  /** 디바운스 타이머: 1초 */
+  DEBOUNCE: 1,
 } as const;
 
 @Injectable()


### PR DESCRIPTION
## Summary
- 자기 자신의 메시지만 무시하도록 변경 (다른 봇 메시지에도 고정메세지 갱신 트리거)
- 디바운스 타이머 3초 → 1초로 단축

## Test plan
- [ ] 다른 봇이 메시지를 보낼 때 고정메세지가 하단으로 이동하는지 확인
- [ ] 자기 자신(dhyunbot)의 고정메세지 전송 시에는 재갱신이 트리거되지 않는지 확인
- [ ] 메시지 전송 후 ~1초 뒤 고정메세지가 갱신되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)