### PR TITLE
fix: mocoNewbieDays 저장 누락 및 기존 버그 수정

### DIFF
--- a/apps/api/src/newbie/infrastructure/newbie-config.repository.ts
+++ b/apps/api/src/newbie/infrastructure/newbie-config.repository.ts
@@ -43,6 +43,7 @@ export class NewbieConfigRepository {
       config.missionEmbedColor = dto.missionEmbedColor ?? null;
       config.missionEmbedThumbnailUrl = dto.missionEmbedThumbnailUrl ?? null;
       config.mocoEnabled = dto.mocoEnabled;
+      config.mocoNewbieDays = dto.mocoNewbieDays ?? 30;
       config.mocoAllowNewbieHunter = dto.mocoAllowNewbieHunter ?? false;
       config.mocoRankChannelId = dto.mocoRankChannelId ?? null;
       config.mocoAutoRefreshMinutes = dto.mocoAutoRefreshMinutes ?? null;
@@ -75,6 +76,7 @@ export class NewbieConfigRepository {
         missionEmbedColor: dto.missionEmbedColor ?? null,
         missionEmbedThumbnailUrl: dto.missionEmbedThumbnailUrl ?? null,
         mocoEnabled: dto.mocoEnabled,
+        mocoNewbieDays: dto.mocoNewbieDays ?? 30,
         mocoAllowNewbieHunter: dto.mocoAllowNewbieHunter ?? false,
         mocoRankChannelId: dto.mocoRankChannelId ?? null,
         mocoRankMessageId: null,


### PR DESCRIPTION
## Summary
- mocoNewbieDays가 upsert에서 누락되어 DB에 저장되지 않던 버그 수정
- DEFAULT_CONFIG에 missionEmbedColor, mocoNewbieDays, mocoEmbedColor 추가
- 봇·탈퇴 멤버 미션 자동 삭제 + 미등록 멤버 갱신 시 자동 등록

## Test plan
- [ ] DB에 mocoNewbieDays 마이그레이션 적용 확인
- [ ] 모코코 사냥 시간이 정상 누적되는지 확인
- [ ] 대시보드에서 mocoNewbieDays 설정 저장/조회 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)