### PR TITLE
ci: main push 시 CI 중복 실행 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [develop, main]
+    branches: [develop]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- PR 머지 시 CI가 push(main) + pull_request(main) 두 트리거로 2번 실행되던 문제 수정
- push 트리거에서 main 브랜치 제거

## Test plan
- [ ] PR 머지 시 CI 1번 + Deploy 1번만 실행되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)