### PR TITLE
fix: 상태 접두사 닉네임 중복 접두사 제거

### DIFF
--- a/apps/api/src/status-prefix/application/status-prefix-apply.service.ts
+++ b/apps/api/src/status-prefix/application/status-prefix-apply.service.ts
@@ -77,9 +77,11 @@ export class StatusPrefixApplyService {
     let originalNickname = await this.redis.getOriginalNickname(guildId, memberId);
 
     if (!originalNickname) {
-      // 최초 접두사 적용 → 현재 displayName을 원래 닉네임으로 NX 저장
-      await this.redis.setOriginalNicknameNx(guildId, memberId, currentDisplayName);
-      originalNickname = currentDisplayName;
+      // 최초 접두사 적용 → 현재 displayName에서 기존 접두사 패턴 제거 후 원래 닉네임으로 저장
+      // 다른 봇이나 수동으로 접두사가 이미 붙어있는 경우 "[관전] [관전] 닉네임" 중복 방지
+      const strippedName = this.configService.stripPrefixFromNickname(currentDisplayName, config);
+      await this.redis.setOriginalNicknameNx(guildId, memberId, strippedName);
+      originalNickname = strippedName;
     }
     // originalNickname이 이미 있으면 기존 값 유지 (덮어쓰기 방지)
 

--- a/apps/api/src/status-prefix/application/status-prefix-config.service.ts
+++ b/apps/api/src/status-prefix/application/status-prefix-config.service.ts
@@ -29,6 +29,49 @@ export class StatusPrefixConfigService {
   ) {}
 
   /**
+   * 닉네임에서 등록된 접두사 패턴을 제거하여 순수 닉네임을 추출한다.
+   * prefixTemplate에서 {prefix} 자리에 등록된 모든 접두사를 대입하여 매칭 후 제거.
+   *
+   * 예: template='[{prefix}] {nickname}', prefixes=['관전','대기']
+   *   - '[관전] 동현'  → '동현'
+   *   - '[관전] [관전] 동현' → '[관전] 동현' → '동현' (반복 제거)
+   *   - '동현' → '동현' (변경 없음)
+   */
+  stripPrefixFromNickname(nickname: string, config: StatusPrefixConfig): string {
+    if (!config.buttons?.length) return nickname;
+
+    const prefixes = config.buttons
+      .filter((b) => b.type === StatusPrefixButtonType.PREFIX && b.prefix?.trim())
+      .map((b) => b.prefix!.trim());
+
+    if (prefixes.length === 0) return nickname;
+
+    // 템플릿에서 정규식 패턴 생성
+    // '[{prefix}] {nickname}' → '^\\[(?:관전|대기)\\]\\s' (앞부분만 매칭)
+    const templateBefore = config.prefixTemplate.split('{nickname}')[0]; // '{prefix}' 포함 앞부분
+    const escapedPrefixes = prefixes.map((p) => p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    const prefixAlt = escapedPrefixes.join('|');
+
+    // templateBefore의 리터럴 부분을 정규식 이스케이프 후, {prefix}를 접두사 대체 그룹으로 치환
+    const escapedTemplate = templateBefore
+      .replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // 전체 이스케이프
+      .replace('\\{prefix\\}', `(?:${prefixAlt})`); // {prefix} 부분만 대체 그룹으로
+
+    const pattern = new RegExp(`^${escapedTemplate}`);
+
+    // 반복 제거 (중첩된 접두사 대응)
+    let result = nickname;
+    let prev: string;
+    do {
+      prev = result;
+      result = result.replace(pattern, '').trim();
+    } while (result !== prev);
+
+    // 스트립 결과가 빈 문자열이면 원본 유지 (닉네임 자체가 접두사 패턴인 극단 케이스)
+    return result || nickname;
+  }
+
+  /**
    * 설정 조회 (F-STATUS-PREFIX-001).
    * Redis 캐시 우선, 미스 시 DB 조회 후 캐시 저장.
    */

--- a/apps/api/src/status-prefix/application/status-prefix-reset.service.ts
+++ b/apps/api/src/status-prefix/application/status-prefix-reset.service.ts
@@ -4,6 +4,7 @@ import { ButtonInteraction, Client, GuildMember } from 'discord.js';
 
 import { StatusPrefixConfigRepository } from '../infrastructure/status-prefix-config.repository';
 import { StatusPrefixRedisRepository } from '../infrastructure/status-prefix-redis.repository';
+import { StatusPrefixConfigService } from './status-prefix-config.service';
 
 @Injectable()
 export class StatusPrefixResetService {
@@ -12,6 +13,7 @@ export class StatusPrefixResetService {
   constructor(
     private readonly configRepo: StatusPrefixConfigRepository,
     private readonly redis: StatusPrefixRedisRepository,
+    private readonly configService: StatusPrefixConfigService,
     @InjectDiscordClient() private readonly discordClient: Client,
   ) {}
 
@@ -48,9 +50,15 @@ export class StatusPrefixResetService {
 
     const member = interaction.member as GuildMember;
 
+    // 2-1. 기존 데이터에 접두사가 남아있을 수 있으므로 스트립 적용 (안전장치)
+    const config = await this.configService.getConfig(guildId);
+    const cleanNickname = config
+      ? this.configService.stripPrefixFromNickname(originalNickname, config)
+      : originalNickname;
+
     // 3. Discord API 닉네임 복원
     try {
-      await member.setNickname(originalNickname);
+      await member.setNickname(cleanNickname);
     } catch (err) {
       this.logger.warn(
         `[STATUS_PREFIX] reset setNickname failed: guild=${guildId} member=${memberId}`,
@@ -73,7 +81,7 @@ export class StatusPrefixResetService {
     });
 
     this.logger.log(
-      `[STATUS_PREFIX] Reset: guild=${guildId} member=${memberId} restored="${originalNickname}"`,
+      `[STATUS_PREFIX] Reset: guild=${guildId} member=${memberId} restored="${cleanNickname}"`,
     );
   }
 
@@ -116,6 +124,12 @@ export class StatusPrefixResetService {
     // 4. 없으면 처리 중단
     if (!originalNickname) return;
 
+    // 4-1. 설정 조회하여 접두사 스트립 적용 (기존 데이터 안전장치)
+    const config = await this.configService.getConfig(guildId);
+    const cleanNickname = config
+      ? this.configService.stripPrefixFromNickname(originalNickname, config)
+      : originalNickname;
+
     // 5. Discord GuildMember fetch (인터랙션 컨텍스트 없이 Client 직접 사용)
     let member: GuildMember;
     try {
@@ -132,7 +146,7 @@ export class StatusPrefixResetService {
 
     // 6. 닉네임 복원
     try {
-      await member.setNickname(originalNickname);
+      await member.setNickname(cleanNickname);
     } catch (err) {
       this.logger.warn(
         `[STATUS_PREFIX] restoreOnLeave setNickname failed: guild=${guildId} member=${memberId}`,
@@ -145,7 +159,7 @@ export class StatusPrefixResetService {
     await this.redis.deleteOriginalNickname(guildId, memberId);
 
     this.logger.log(
-      `[STATUS_PREFIX] restoreOnLeave: guild=${guildId} member=${memberId} restored="${originalNickname}"`,
+      `[STATUS_PREFIX] restoreOnLeave: guild=${guildId} member=${memberId} restored="${cleanNickname}"`,
     );
   }
 }


### PR DESCRIPTION
## Summary
- 다른 봇과의 혼용으로 `[관전] [관전] 닉네임` 중복 접두사 문제 및 리셋 시 접두사가 남는 버그 수정
- `stripPrefixFromNickname()` 메서드 추가: 템플릿 기반 정규식으로 중첩된 접두사를 반복 제거
- 접두사 적용(apply) 시 기존 접두사를 스트립한 후 원래 닉네임 저장
- 리셋(reset) 및 음성 퇴장 복원(restoreOnLeave) 시 레거시 데이터 안전장치로 스트립 적용

## Test plan
- [ ] 접두사가 이미 붙어있는 닉네임(`[관전] 동현`)에 접두사 적용 → `[관전] 동현` (중복 없음)
- [ ] 중첩 접두사(`[관전] [관전] 동현`) 상태에서 리셋 → `동현` (완전 복원)
- [ ] 접두사 없는 일반 닉네임에 접두사 적용/리셋 → 기존과 동일 동작
- [ ] 음성 채널 퇴장 시 닉네임 자동 복원 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)