### PR TITLE
fix: CI lightningcss 네이티브 바이너리 누락 수정

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "lightningcss": "^1.30.2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7816,6 +7816,7 @@
         "autoprefixer": "^10.4.23",
         "eslint": "^9",
         "eslint-config-next": "16.1.0",
+        "lightningcss": "^1.30.2",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.2.1",
         "typescript": "^5"


### PR DESCRIPTION
## Summary
- `lightningcss`를 `apps/web/package.json`의 명시적 `devDependencies`로 추가
- `@tailwindcss/postcss` → `@tailwindcss/node` → `lightningcss` 간접 의존 시 npm workspace 환경에서 플랫폼별 네이티브 바이너리(`lightningcss-linux-x64-gnu`)가 설치되지 않는 문제 해결
- 이전 PR #23 (중복 lockfile 삭제)만으로는 해결되지 않아 근본 원인 수정

## Test plan
- [ ] CI `Build Web` 단계 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)