### PR TITLE
fix: CI lightningcss 네이티브 바이너리 rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Rebuild native modules
+        run: npm rebuild lightningcss
+
       - name: Lint
         run: npm run lint
 


### PR DESCRIPTION
## Summary
- CI workflow에 `npm rebuild lightningcss` 단계 추가
- npm workspace 환경에서 `lightningcss`의 platform-specific optional deps가 올바른 위치에 설치되지 않아 `next build` 실패하는 문제 해결
- Windows에서 생성된 lockfile은 Linux optional deps 설치 경로를 포함하지 않음 → rebuild로 해결

## Test plan
- [ ] CI `Build Web` 단계 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)