### PR TITLE
fix: CI npm ci → npm install (크로스 플랫폼 호환)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,7 @@ jobs:
           node-version: 20
           cache: npm
 
-      - run: npm ci
-
-      - name: Rebuild native modules
-        run: npm rebuild lightningcss
+      - run: npm install
 
       - name: Lint
         run: npm run lint


### PR DESCRIPTION
## Summary
- CI에서 `npm ci` → `npm install`로 변경
- Windows에서 생성된 lockfile에 Linux 플랫폼용 optional deps(`lightningcss-linux-x64-gnu`) 설치 엔트리가 없어 `npm ci`로는 네이티브 바이너리가 설치되지 않는 근본 원인 수정
- `npm install`은 현재 플랫폼에 맞는 optional deps를 자동으로 resolve
- 이전 시도(`npm rebuild`, 명시적 dep 추가)로는 해결되지 않았던 문제

## Test plan
- [ ] CI 전체 통과 확인 (Lint + Build shared + Build API + Build Web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)