### PR TITLE
feat: CI/CD를 pre-build + push 방식으로 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,59 @@ on:
   push:
     branches: [main]
 
+env:
+  REGISTRY: ghcr.io
+  API_IMAGE: ghcr.io/${{ github.repository }}/api
+  WEB_IMAGE: ghcr.io/${{ github.repository }}/web
+
 jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push API image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/api/Dockerfile.prod
+          push: true
+          tags: |
+            ${{ env.API_IMAGE }}:latest
+            ${{ env.API_IMAGE }}:${{ github.sha }}
+          cache-from: type=gha,scope=api
+          cache-to: type=gha,mode=max,scope=api
+
+      - name: Build and push Web image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/web/Dockerfile.prod
+          push: true
+          tags: |
+            ${{ env.WEB_IMAGE }}:latest
+            ${{ env.WEB_IMAGE }}:${{ github.sha }}
+          cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=max,scope=web
+
   deploy:
     runs-on: ubuntu-latest
-    needs: []
+    needs: build-and-push
 
     steps:
       - name: Deploy via SSH
@@ -19,7 +68,19 @@ jobs:
           script: |
             set -e
             cd ~/nestjs-dhyunbot
+
+            # docker-compose.prod.yml 업데이트
             git pull origin main
-            docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build
+
+            # ghcr.io 로그인
+            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+            # 새 이미지 pull & 컨테이너 재시작
+            docker compose --env-file .env.prod -f docker-compose.prod.yml pull api web
+            docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
+
+            # DB 마이그레이션
             docker compose --env-file .env.prod -f docker-compose.prod.yml exec api npx typeorm migration:run -d dist/apps/api/src/data-source.js
+
+            # 사용하지 않는 이미지 정리
             docker image prune -f

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,10 +1,7 @@
 services:
   api:
     container_name: nest-api-prod
-    image: nest-dhyunbot-api-prod
-    build:
-      context: .
-      dockerfile: apps/api/Dockerfile.prod
+    image: ghcr.io/sambart/nestjs-dhyunbot/api:latest
     ports:
       - "3000:3000"
     env_file:
@@ -20,10 +17,7 @@ services:
 
   web:
     container_name: next-web-prod
-    image: nest-dhyunbot-web-prod
-    build:
-      context: .
-      dockerfile: apps/web/Dockerfile.prod
+    image: ghcr.io/sambart/nestjs-dhyunbot/web:latest
     ports:
       - "4000:4000"
     env_file:

--- a/docs/deploy-guide.md
+++ b/docs/deploy-guide.md
@@ -4,7 +4,9 @@
 
 ```
 GitHub (develop push) → CI 검증 (lint + build)
-GitHub (main push)    → CI 검증 → Lightsail SSH 배포
+GitHub (main push)    → CI 검증 → GitHub Actions에서 Docker 이미지 빌드
+                      → ghcr.io에 이미지 push
+                      → Lightsail SSH 접속 → 이미지 pull → 컨테이너 재시작
 ```
 
 ---
@@ -26,23 +28,13 @@ docker --version
 docker compose version
 ```
 
-### 1-2. Swap 추가 (저사양 인스턴스 권장)
-
-```bash
-sudo fallocate -l 2G /swapfile
-sudo chmod 600 /swapfile
-sudo mkswap /swapfile
-sudo swapon /swapfile
-echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
-```
-
-### 1-3. 타임존 설정
+### 1-2. 타임존 설정
 
 ```bash
 sudo timedatectl set-timezone Asia/Seoul
 ```
 
-### 1-4. 방화벽
+### 1-3. 방화벽
 
 ```bash
 sudo ufw allow OpenSSH
@@ -53,18 +45,29 @@ sudo ufw enable
 
 > Lightsail 콘솔 > Networking 탭에서도 3000, 4000 포트를 열어야 한다.
 
-### 1-5. 프로젝트 클론 + 환경변수
+### 1-4. 프로젝트 클론 + 환경변수
 
 ```bash
-git clone <repo-url> ~/nest-dhyunbot
-cd ~/nest-dhyunbot
+git clone <repo-url> ~/nestjs-dhyunbot
+cd ~/nestjs-dhyunbot
 nano .env.prod   # 환경변수 입력
 ```
+
+### 1-5. ghcr.io 로그인
+
+서버에서 GitHub Container Registry의 이미지를 pull하려면 로그인이 필요하다.
+
+```bash
+echo "<GHCR_TOKEN>" | docker login ghcr.io -u <GITHUB_USERNAME> --password-stdin
+```
+
+> `GHCR_TOKEN`은 GitHub > Settings > Developer settings > Personal access tokens에서 `read:packages` 권한으로 생성한다.
 
 ### 1-6. 최초 실행
 
 ```bash
-docker compose -f docker-compose.prod.yml up -d --build
+docker compose --env-file .env.prod -f docker-compose.prod.yml pull api web
+docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
 ```
 
 ---
@@ -73,15 +76,22 @@ docker compose -f docker-compose.prod.yml up -d --build
 
 리포지토리 > Settings > Secrets and variables > Actions에 추가:
 
-| Secret | 값 | 예시 |
+| Secret | 설명 | 예시 |
 |---|---|---|
 | `LIGHTSAIL_HOST` | Lightsail 퍼블릭 IP | `STATIC_IP` |
 | `LIGHTSAIL_USER` | SSH 유저명 | `ubuntu` |
 | `LIGHTSAIL_SSH_KEY` | SSH 프라이빗 키 전체 내용 | `-----BEGIN RSA PRIVATE KEY-----\n...` |
+| `GHCR_TOKEN` | GitHub PAT (`read:packages` 권한) | `ghp_xxxx...` |
 
 ### SSH 키 확인 방법
 
 Lightsail 콘솔에서 다운로드한 `.pem` 파일 내용 전체를 `LIGHTSAIL_SSH_KEY`에 붙여넣는다.
+
+### GHCR_TOKEN 생성 방법
+
+1. GitHub > Settings > Developer settings > Personal access tokens > Tokens (classic)
+2. `read:packages` 권한 체크 후 생성
+3. 생성된 토큰을 `GHCR_TOKEN` Secret에 등록
 
 ---
 
@@ -97,9 +107,14 @@ Lightsail 콘솔에서 다운로드한 `.pem` 파일 내용 전체를 `LIGHTSAIL
 
 ### Deploy (`deploy.yml`)
 
-| 트리거 | 동작 |
+| 단계 | 동작 |
 |---|---|
-| `main` push | Lightsail SSH 접속 → `git pull` → `docker compose up --build -d` |
+| 1. 빌드 (GitHub Actions) | Docker 이미지 빌드 → ghcr.io에 push (`api`, `web`) |
+| 2. 배포 (Lightsail SSH) | `docker compose pull` → `up -d` → DB 마이그레이션 |
+
+이미지 태그:
+- `latest` — 항상 최신 배포 버전
+- `<commit-sha>` — 특정 커밋 버전 (롤백용)
 
 ---
 
@@ -108,7 +123,7 @@ Lightsail 콘솔에서 다운로드한 `.pem` 파일 내용 전체를 `LIGHTSAIL
 ```
 1. develop 브랜치에서 작업 + push → CI 자동 검증
 2. develop → main PR 생성 → CI 자동 검증
-3. main에 merge → CI 검증 + 자동 배포
+3. main에 merge → CI 검증 + Docker 이미지 빌드/push + 자동 배포
 ```
 
 ---
@@ -117,15 +132,35 @@ Lightsail 콘솔에서 다운로드한 `.pem` 파일 내용 전체를 `LIGHTSAIL
 
 ```bash
 ssh ubuntu@<LIGHTSAIL_IP>
-cd ~/nest-dhyunbot
+cd ~/nestjs-dhyunbot
 git pull origin main
-docker compose -f docker-compose.prod.yml up -d --build
+docker compose --env-file .env.prod -f docker-compose.prod.yml pull api web
+docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
 docker image prune -f
 ```
 
 ---
 
-## 6. 운영 명령어
+## 6. 롤백
+
+특정 커밋의 이미지로 롤백할 수 있다.
+
+```bash
+ssh ubuntu@<LIGHTSAIL_IP>
+cd ~/nestjs-dhyunbot
+
+# 특정 커밋의 이미지로 롤백
+docker compose --env-file .env.prod -f docker-compose.prod.yml pull \
+  ghcr.io/sambart/nestjs-dhyunbot/api:<commit-sha> \
+  ghcr.io/sambart/nestjs-dhyunbot/web:<commit-sha>
+
+# docker-compose.prod.yml에서 image 태그를 해당 commit-sha로 변경 후
+docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
+```
+
+---
+
+## 7. 운영 명령어
 
 ```bash
 # 로그 확인
@@ -138,8 +173,9 @@ docker compose -f docker-compose.prod.yml restart api
 # 전체 중지
 docker compose -f docker-compose.prod.yml down
 
-# 전체 재빌드 + 시작
-docker compose -f docker-compose.prod.yml up -d --build
+# 최신 이미지 pull + 재시작
+docker compose --env-file .env.prod -f docker-compose.prod.yml pull api web
+docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
 
 # 미사용 이미지 정리
 docker image prune -f
@@ -150,14 +186,16 @@ docker exec -it postgres-prod psql -U $DATABASE_USER -d $DATABASE_NAME
 
 ---
 
-## 7. 트러블슈팅
+## 8. 트러블슈팅
 
-### 빌드 실패 시
+### 이미지 pull 실패 시
 
 ```bash
-# 캐시 없이 재빌드
-docker compose -f docker-compose.prod.yml build --no-cache
-docker compose -f docker-compose.prod.yml up -d
+# ghcr.io 로그인 확인
+docker login ghcr.io
+
+# 토큰 재설정
+echo "<GHCR_TOKEN>" | docker login ghcr.io -u <GITHUB_USERNAME> --password-stdin
 ```
 
 ### 디스크 부족 시


### PR DESCRIPTION
## Summary
- Docker 이미지를 서버에서 빌드하던 방식에서 GitHub Actions에서 빌드 후 ghcr.io에 push하는 방식으로 전환
- 서버에서는 이미지 pull + 컨테이너 재시작만 수행하여 메모리 부족 문제 해결
- 배포 가이드 문서를 새로운 방식에 맞게 업데이트 (롤백 가이드, GHCR_TOKEN 설정 등 추가)

## Test plan
- [ ] GitHub Secrets에 `GHCR_TOKEN` 등록
- [ ] main merge 후 GitHub Actions 워크플로우 정상 실행 확인
- [ ] ghcr.io에 이미지 push 성공 확인
- [ ] Lightsail 서버에서 이미지 pull + 컨테이너 정상 기동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)