### PR TITLE
fix: Header.tsx import 정렬 lint 오류 수정

### DIFF
--- a/apps/web/app/components/Header.tsx
+++ b/apps/web/app/components/Header.tsx
@@ -2,8 +2,8 @@
 
 import { Home, LayoutDashboard, Menu, Settings, X } from "lucide-react";
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export interface Guild {
   id: string;


### PR DESCRIPTION
## Summary
- `Header.tsx`에서 `useRouter` import 위치가 `simple-import-sort` 규칙에 맞지 않아 CI lint 실패
- `next/navigation` → `react` 순서로 정렬 수정

## Test plan
- [ ] CI lint 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)