### PR TITLE
fix: 음악 설정 비활성화 시 channelId 유효성 검사 오류 수정

### DIFF
--- a/apps/api/src/music/dto/music-channel-config.dto.ts
+++ b/apps/api/src/music/dto/music-channel-config.dto.ts
@@ -7,6 +7,7 @@ import {
   IsString,
   Max,
   Min,
+  ValidateIf,
   ValidateNested,
 } from 'class-validator';
 
@@ -39,6 +40,7 @@ export class MusicButtonConfigJsonDto implements MusicButtonConfigJson {
 
 export class MusicChannelConfigSaveDto {
   @IsString()
+  @ValidateIf((o: MusicChannelConfigSaveDto) => o.enabled)
   @IsNotEmpty()
   channelId: string;
 


### PR DESCRIPTION
## Summary
- 음악 설정을 disable로 변경 시 `channelId should not be empty` 에러 발생하는 버그 수정
- `@ValidateIf((o) => o.enabled)`를 적용하여 `enabled: false`일 때 `channelId` 빈 값 허용

## Test plan
- [ ] 음악 설정에서 채널 미선택 상태로 enabled=false 저장 시 에러 없이 저장되는지 확인
- [ ] enabled=true일 때 channelId 필수 검증은 기존대로 작동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)