### PR TITLE
fix: auth throttle limit 완화, Lavalink OAuth 활성화, Docker 빌드 개선

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,6 +54,8 @@ docs
 !README.md
 
 # Docker
-Dockerfile*
 docker-compose*.yml
+docker-bake.hcl
 .dockerignore
+apps/*/Dockerfile
+apps/*/Dockerfile.prod

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,44 +83,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push API image
-        uses: docker/build-push-action@v6
+      - name: Build and push all images
+        uses: docker/bake-action@v6
         with:
-          context: .
-          file: apps/api/Dockerfile.prod
+          files: docker-bake.hcl
           push: true
-          tags: |
-            ${{ env.API_IMAGE }}:latest
-            ${{ env.API_IMAGE }}:${{ github.sha }}
-            ${{ env.API_IMAGE }}:v${{ needs.version-bump.outputs.new_version }}
-          cache-from: type=gha,scope=api
-          cache-to: type=gha,mode=max,scope=api
-
-      - name: Build and push Bot image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: apps/bot/Dockerfile.prod
-          push: true
-          tags: |
-            ${{ env.BOT_IMAGE }}:latest
-            ${{ env.BOT_IMAGE }}:${{ github.sha }}
-            ${{ env.BOT_IMAGE }}:v${{ needs.version-bump.outputs.new_version }}
-          cache-from: type=gha,scope=bot
-          cache-to: type=gha,mode=max,scope=bot
-
-      - name: Build and push Web image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: apps/web/Dockerfile.prod
-          push: true
-          tags: |
-            ${{ env.WEB_IMAGE }}:latest
-            ${{ env.WEB_IMAGE }}:${{ github.sha }}
-            ${{ env.WEB_IMAGE }}:v${{ needs.version-bump.outputs.new_version }}
-          cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=max,scope=web
+        env:
+          VERSION: v${{ needs.version-bump.outputs.new_version }}
+          SHA: ${{ github.sha }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,141 @@
+# =============================================================================
+# Unified multi-target production Dockerfile
+# Usage: docker buildx bake -f docker-bake.hcl --push
+# =============================================================================
+
+# ── Stage 1: 의존성 설치 (1회, 전체 워크스페이스) ──
+FROM node:20-alpine AS deps
+
+ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
+
+ENV HUSKY=0
+WORKDIR /workspace
+
+# 워크스페이스 설정 + lockfile (캐시 레이어 최적화)
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc tsconfig.json ./
+COPY apps/api/package.json ./apps/api/
+COPY apps/bot/package.json ./apps/bot/
+COPY apps/web/package.json ./apps/web/
+COPY libs/shared/package.json ./libs/shared/
+COPY libs/bot-api-client/package.json ./libs/bot-api-client/
+COPY libs/i18n/package.json ./libs/i18n/
+
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
+
+# ── Stage 2: 공유 라이브러리 빌드 (1회) ──
+FROM deps AS libs-builder
+
+COPY libs/shared ./libs/shared
+RUN pnpm --filter @onyu/shared build
+
+COPY libs/bot-api-client ./libs/bot-api-client
+RUN pnpm --filter @onyu/bot-api-client build
+
+COPY libs/i18n ./libs/i18n
+
+# ── Stage 3a: API 빌더 ──
+FROM libs-builder AS api-builder
+COPY apps/api ./apps/api
+WORKDIR /workspace/apps/api
+RUN pnpm run build
+
+# ── Stage 3b: Bot 빌더 ──
+FROM libs-builder AS bot-builder
+COPY apps/bot ./apps/bot
+WORKDIR /workspace/apps/bot
+RUN pnpm run build
+
+# ── Stage 3c: Web 빌더 ──
+FROM libs-builder AS web-builder
+COPY apps/web ./apps/web
+WORKDIR /workspace/apps/web
+RUN --mount=type=cache,target=/root/.cache pnpm run build
+
+# ── 프로덕션 공통 base ──
+FROM node:20-alpine AS prod-base
+
+ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
+
+ENV HUSKY=0
+WORKDIR /workspace
+
+# ── API 프로덕션 ──
+FROM prod-base AS api
+
+# Fonts for canvas (Korean + Emoji support)
+RUN apk add --no-cache fontconfig font-noto-cjk font-noto-emoji
+
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
+COPY apps/api/package.json ./apps/api/
+COPY libs/shared/package.json ./libs/shared/
+COPY libs/bot-api-client/package.json ./libs/bot-api-client/
+COPY libs/i18n/package.json ./libs/i18n/
+
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --prod
+
+COPY --from=libs-builder /workspace/libs/shared/dist ./libs/shared/dist
+COPY --from=libs-builder /workspace/libs/shared/package.json ./libs/shared/
+COPY --from=libs-builder /workspace/libs/bot-api-client/dist ./libs/bot-api-client/dist
+COPY --from=libs-builder /workspace/libs/bot-api-client/package.json ./libs/bot-api-client/
+COPY --from=libs-builder /workspace/libs/i18n ./libs/i18n
+
+COPY --from=api-builder /workspace/apps/api/dist ./apps/api/dist
+COPY --from=api-builder /workspace/apps/api/package.json ./apps/api/
+
+WORKDIR /workspace/apps/api
+EXPOSE 3000
+CMD ["node", "dist/apps/api/src/main.js"]
+
+# ── Bot 프로덕션 ──
+FROM prod-base AS bot
+
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
+COPY apps/bot/package.json ./apps/bot/
+COPY libs/shared/package.json ./libs/shared/
+COPY libs/bot-api-client/package.json ./libs/bot-api-client/
+COPY libs/i18n/package.json ./libs/i18n/
+
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --prod
+
+COPY --from=libs-builder /workspace/libs/shared/dist ./libs/shared/dist
+COPY --from=libs-builder /workspace/libs/shared/package.json ./libs/shared/
+COPY --from=libs-builder /workspace/libs/bot-api-client/dist ./libs/bot-api-client/dist
+COPY --from=libs-builder /workspace/libs/bot-api-client/package.json ./libs/bot-api-client/
+COPY --from=libs-builder /workspace/libs/i18n ./libs/i18n
+
+COPY --from=bot-builder /workspace/apps/bot/dist ./apps/bot/dist
+COPY --from=bot-builder /workspace/apps/bot/package.json ./apps/bot/
+
+WORKDIR /workspace/apps/bot
+CMD ["node", "dist/apps/bot/src/main.js"]
+
+# ── Web 프로덕션 ──
+FROM prod-base AS web
+
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
+COPY apps/web/package.json ./apps/web/
+COPY libs/shared/package.json ./libs/shared/
+COPY libs/i18n/package.json ./libs/i18n/
+
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --prod
+
+COPY --from=libs-builder /workspace/libs/shared/dist ./libs/shared/dist
+COPY --from=libs-builder /workspace/libs/shared/package.json ./libs/shared/
+COPY --from=libs-builder /workspace/libs/i18n ./libs/i18n
+
+COPY --from=web-builder /workspace/apps/web/.next ./apps/web/.next
+COPY --from=web-builder /workspace/apps/web/public ./apps/web/public
+COPY --from=web-builder /workspace/apps/web/package.json ./apps/web/
+COPY --from=web-builder /workspace/apps/web/next.config.mjs ./apps/web/
+
+WORKDIR /workspace/apps/web
+EXPOSE 4000
+CMD ["pnpm", "start"]

--- a/apps/api/src/auth/presentation/auth.controller.ts
+++ b/apps/api/src/auth/presentation/auth.controller.ts
@@ -5,7 +5,7 @@ import { Throttle } from '@nestjs/throttler';
 
 import { AuthService } from '../application/auth.service';
 
-@Throttle({ default: { ttl: 60000, limit: 5 } })
+@Throttle({ default: { ttl: 60000, limit: 10 } })
 @Controller('auth/discord')
 export class AuthController {
   constructor(

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,51 @@
+group "default" {
+  targets = ["api", "bot", "web"]
+}
+
+variable "REGISTRY" {
+  default = "ghcr.io/sambart/onyu"
+}
+
+variable "VERSION" {
+  default = "latest"
+}
+
+variable "SHA" {
+  default = ""
+}
+
+target "api" {
+  dockerfile = "Dockerfile.prod"
+  target     = "api"
+  tags = compact([
+    "${REGISTRY}/api:latest",
+    SHA != "" ? "${REGISTRY}/api:${SHA}" : "",
+    VERSION != "latest" ? "${REGISTRY}/api:${VERSION}" : "",
+  ])
+  cache-from = ["type=gha,scope=prod"]
+  cache-to   = ["type=gha,mode=max,scope=prod"]
+}
+
+target "bot" {
+  dockerfile = "Dockerfile.prod"
+  target     = "bot"
+  tags = compact([
+    "${REGISTRY}/bot:latest",
+    SHA != "" ? "${REGISTRY}/bot:${SHA}" : "",
+    VERSION != "latest" ? "${REGISTRY}/bot:${VERSION}" : "",
+  ])
+  cache-from = ["type=gha,scope=prod"]
+  cache-to   = ["type=gha,mode=max,scope=prod"]
+}
+
+target "web" {
+  dockerfile = "Dockerfile.prod"
+  target     = "web"
+  tags = compact([
+    "${REGISTRY}/web:latest",
+    SHA != "" ? "${REGISTRY}/web:${SHA}" : "",
+    VERSION != "latest" ? "${REGISTRY}/web:${VERSION}" : "",
+  ])
+  cache-from = ["type=gha,scope=prod"]
+  cache-to   = ["type=gha,mode=max,scope=prod"]
+}

--- a/lavalink/application.yml
+++ b/lavalink/application.yml
@@ -25,8 +25,11 @@ plugins:
     allowDirectPlaylistIds: true
     clients:
       - MUSIC
+      - TVHTML5EMBEDDED
       - WEB
       - ANDROID_VR
+    oauth:
+      enabled: true
 
 logging:
   level:


### PR DESCRIPTION
## Summary
- auth/discord 엔드포인트 rate limit 5 → 10으로 완화 (429 에러 빈번 발생)
- Lavalink YouTube 플러그인 OAuth 인증 활성화 및 TVHTML5EMBEDDED 클라이언트 추가 (prod 서버 "requires login" 에러 해결)
- Docker 빌드를 docker-bake로 통합하여 병렬 빌드 지원

## Test plan
- [ ] prod 서버에서 음악 재생 시 "requires login" 에러 해결 확인
- [ ] Lavalink 로그에서 OAuth 인증 URL 확인 후 Google 계정 로그인
- [ ] auth/discord 엔드포인트 접속 시 429 에러 빈도 감소 확인
- [ ] Docker 빌드 파이프라인 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)