### PR TITLE
feat: 자동방 버튼 그룹핑 및 서버진단 개선

### DIFF
--- a/apps/api/src/channel/auto/application/auto-channel-bootstrap.service.spec.ts
+++ b/apps/api/src/channel/auto/application/auto-channel-bootstrap.service.spec.ts
@@ -32,10 +32,10 @@ describe('AutoChannelBootstrapService', () => {
       await expect(service.onApplicationBootstrap()).resolves.not.toThrow();
     });
 
-    it('설정 조회 실패 시 에러를 throw한다', async () => {
+    it('설정 조회 실패 시 에러를 삼키고 정상 완료된다', async () => {
       configRepo.findAllConfigs.mockRejectedValue(new Error('DB 연결 실패'));
 
-      await expect(service.onApplicationBootstrap()).rejects.toThrow('DB 연결 실패');
+      await expect(service.onApplicationBootstrap()).resolves.not.toThrow();
     });
 
     it('설정 수와 무관하게 findAllConfigs를 1번만 호출한다', async () => {

--- a/apps/api/src/channel/auto/application/auto-channel.service.spec.ts
+++ b/apps/api/src/channel/auto/application/auto-channel.service.spec.ts
@@ -55,7 +55,7 @@ function makeButton(
     channelNameTemplate: string | null;
     sortOrder: number;
     subOptions: unknown[];
-    config: unknown;
+    config: ReturnType<typeof makeConfig>;
   }> = {},
 ) {
   const config = makeConfig({ mode: 'select', id: overrides.configId ?? 1 });
@@ -784,6 +784,99 @@ describe('AutoChannelService', () => {
       expect(autoChannelDiscordGateway.editGuideMessage).toHaveBeenCalledOnce();
       expect(autoChannelDiscordGateway.sendGuideMessage).toHaveBeenCalledOnce();
       expect(configRepo.updateGuideMessageId).toHaveBeenCalledWith(1, 'new-msg-id');
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────
+  // cacheAutoChannelInfo — buttonId/buttonLabel 저장 (F-VOICE-032)
+  // ────────────────────────────────────────────────────────────
+
+  describe('cacheAutoChannelInfo — buttonId/buttonLabel 저장', () => {
+    it('버튼 클릭으로 확정방 생성 시 buttonId와 buttonLabel이 setAutoChannelInfo에 전달된다', async () => {
+      const button = makeButton({ id: 10, configId: 1, label: '오버워치' });
+      button.config.id = 1;
+      button.config.triggerChannelId = 'trigger-ch';
+      (button.config as unknown as Record<string, unknown>).name = '게임방';
+      configRepo.findButtonById.mockResolvedValue(button);
+      discordVoiceGateway.createVoiceChannel.mockResolvedValue('confirmed-ch');
+
+      await service.handleButtonClickFromBot({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        displayName: 'Onyu',
+        buttonId: 10,
+        voiceChannelId: 'trigger-ch',
+      });
+
+      expect(voiceRedisRepository.setAutoChannelInfo).toHaveBeenCalledWith(
+        'guild-1',
+        'confirmed-ch',
+        expect.objectContaining({
+          configId: 1,
+          channelType: 'auto_select',
+          buttonId: 10,
+          buttonLabel: '오버워치',
+        }),
+      );
+    });
+
+    it('instant 모드 확정방 생성 시 buttonId=null, buttonLabel=null이 setAutoChannelInfo에 전달된다', async () => {
+      const config = makeConfig({
+        id: 42,
+        instantCategoryId: 'cat-instant',
+        instantNameTemplate: '{username}의 방',
+      });
+      // makeConfig에 name이 없으므로 직접 할당
+      (config as unknown as Record<string, unknown>).name = '즉시생성방';
+      configRepo.findByTriggerChannel.mockResolvedValue(config);
+      discordVoiceGateway.createVoiceChannel.mockResolvedValue('instant-ch');
+
+      await service.handleInstantTriggerJoin({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        triggerChannelId: 'trigger-ch-1',
+        displayName: 'Onyu',
+      });
+
+      expect(voiceRedisRepository.setAutoChannelInfo).toHaveBeenCalledWith(
+        'guild-1',
+        'instant-ch',
+        expect.objectContaining({
+          configId: 42,
+          channelType: 'auto_instant',
+          buttonId: null,
+          buttonLabel: null,
+        }),
+      );
+    });
+
+    it('하위 선택지 클릭으로 확정방 생성 시 버튼의 buttonId와 buttonLabel이 전달된다', async () => {
+      const button = makeButton({ id: 20, configId: 5, label: '팀데스매치' });
+      button.config.id = 5;
+      button.config.triggerChannelId = 'trigger-ch';
+      (button.config as unknown as Record<string, unknown>).name = '게임방';
+      const subOption = makeSubOption({ id: 30, button });
+      configRepo.findSubOptionById.mockResolvedValue(subOption);
+      discordVoiceGateway.createVoiceChannel.mockResolvedValue('sub-confirmed-ch');
+
+      await service.handleSubOptionClickFromBot({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        displayName: 'Onyu',
+        subOptionId: 30,
+        voiceChannelId: 'trigger-ch',
+      });
+
+      expect(voiceRedisRepository.setAutoChannelInfo).toHaveBeenCalledWith(
+        'guild-1',
+        'sub-confirmed-ch',
+        expect.objectContaining({
+          configId: 5,
+          channelType: 'auto_select',
+          buttonId: 20,
+          buttonLabel: '팀데스매치',
+        }),
+      );
     });
   });
 });

--- a/apps/api/src/channel/auto/application/auto-channel.service.ts
+++ b/apps/api/src/channel/auto/application/auto-channel.service.ts
@@ -333,6 +333,8 @@ export class AutoChannelService {
       configId: button.configId,
       configName: button.config.name,
       channelType: 'auto_select',
+      buttonId: button.id,
+      buttonLabel: button.label,
     });
 
     // 5. 세션 추적 시작 (F-VOICE-001과 동일)
@@ -637,6 +639,8 @@ export class AutoChannelService {
       configId: button.configId,
       configName: button.config.name,
       channelType: 'auto_select',
+      buttonId: button.id,
+      buttonLabel: button.label,
     });
 
     this.logger.log(
@@ -735,6 +739,8 @@ export class AutoChannelService {
         configId: config.id,
         configName: config.name,
         channelType: 'auto_instant',
+        buttonId: null,
+        buttonLabel: null,
       });
 
       this.logger.log(
@@ -771,17 +777,23 @@ export class AutoChannelService {
     configId,
     configName,
     channelType,
+    buttonId,
+    buttonLabel,
   }: {
     guildId: string;
     channelId: string;
     configId: number;
     configName: string;
     channelType: 'auto_select' | 'auto_instant';
+    buttonId: number | null;
+    buttonLabel: string | null;
   }): Promise<void> {
     await this.voiceRedisRepository.setAutoChannelInfo(guildId, channelId, {
       configId,
       configName,
       channelType,
+      buttonId,
+      buttonLabel,
     });
   }
 

--- a/apps/api/src/channel/voice/application/voice-daily-flush-auto-channel.spec.ts
+++ b/apps/api/src/channel/voice/application/voice-daily-flush-auto-channel.spec.ts
@@ -67,6 +67,8 @@ describe('VoiceDailyFlushService — auto-channel 메타데이터 flush', () => 
         configId: 1,
         configName: '게임방',
         channelType: 'auto_select',
+        buttonId: 10,
+        buttonLabel: '게임',
       };
       voiceRedisRepository.getAutoChannelInfo.mockResolvedValue(autoInfo);
       voiceRedisRepository.getUserName.mockResolvedValue('Alice');
@@ -80,6 +82,8 @@ describe('VoiceDailyFlushService — auto-channel 메타데이터 flush', () => 
           channelType: 'auto_select',
           autoChannelConfigId: 1,
           autoChannelConfigName: '게임방',
+          autoChannelButtonId: 10,
+          autoChannelButtonLabel: '게임',
         }),
       );
     });
@@ -92,6 +96,8 @@ describe('VoiceDailyFlushService — auto-channel 메타데이터 flush', () => 
         configId: 42,
         configName: '즉시생성방',
         channelType: 'auto_instant',
+        buttonId: null,
+        buttonLabel: null,
       };
       voiceRedisRepository.getAutoChannelInfo.mockResolvedValue(autoInfo);
       voiceRedisRepository.getUserName.mockResolvedValue('Alice');
@@ -167,6 +173,8 @@ describe('VoiceDailyFlushService — auto-channel 메타데이터 flush', () => 
         configId: 5,
         configName: '음성방',
         channelType: 'auto_select',
+        buttonId: 20,
+        buttonLabel: '음성',
       };
       voiceRedisRepository.getAutoChannelInfo.mockResolvedValue(autoInfo);
       voiceRedisRepository.getUserName.mockResolvedValue('Alice');
@@ -208,6 +216,77 @@ describe('VoiceDailyFlushService — auto-channel 메타데이터 flush', () => 
 
       const remaining = await redis.get(channelKey);
       expect(remaining).toBeNull();
+    });
+
+    it('autoChannelInfo에 buttonId=10, buttonLabel=게임이 있으면 accumulateChannelDuration에 전달된다', async () => {
+      const channelKey = `voice:duration:channel:${guild}:${user}:${date}:${channelId}`;
+      await redis.set(channelKey, 300);
+
+      const autoInfo: AutoChannelInfo = {
+        configId: 1,
+        configName: '게임방',
+        channelType: 'auto_select',
+        buttonId: 10,
+        buttonLabel: '게임',
+      };
+      voiceRedisRepository.getAutoChannelInfo.mockResolvedValue(autoInfo);
+      voiceRedisRepository.getUserName.mockResolvedValue('Alice');
+      voiceRedisRepository.getChannelName.mockResolvedValue('게임방-1호');
+      voiceRedisRepository.getCategoryInfo.mockResolvedValue(null);
+
+      await service.flushDate(guild, user, date);
+
+      expect(voiceDailyRepository.accumulateChannelDuration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          autoChannelButtonId: 10,
+          autoChannelButtonLabel: '게임',
+        }),
+      );
+    });
+
+    it('autoChannelInfo의 buttonId=null, buttonLabel=null이면 accumulateChannelDuration에 null이 전달된다', async () => {
+      const channelKey = `voice:duration:channel:${guild}:${user}:${date}:${channelId}`;
+      await redis.set(channelKey, 300);
+
+      const autoInfo: AutoChannelInfo = {
+        configId: 42,
+        configName: '즉시생성방',
+        channelType: 'auto_instant',
+        buttonId: null,
+        buttonLabel: null,
+      };
+      voiceRedisRepository.getAutoChannelInfo.mockResolvedValue(autoInfo);
+      voiceRedisRepository.getUserName.mockResolvedValue('Alice');
+      voiceRedisRepository.getChannelName.mockResolvedValue('즉시방-1호');
+      voiceRedisRepository.getCategoryInfo.mockResolvedValue(null);
+
+      await service.flushDate(guild, user, date);
+
+      expect(voiceDailyRepository.accumulateChannelDuration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          autoChannelButtonId: null,
+          autoChannelButtonLabel: null,
+        }),
+      );
+    });
+
+    it('autoChannelInfo가 null일 때 buttonId=null, buttonLabel=null이 전달된다', async () => {
+      const channelKey = `voice:duration:channel:${guild}:${user}:${date}:${channelId}`;
+      await redis.set(channelKey, 300);
+
+      voiceRedisRepository.getAutoChannelInfo.mockResolvedValue(null);
+      voiceRedisRepository.getUserName.mockResolvedValue('Alice');
+      voiceRedisRepository.getChannelName.mockResolvedValue('일반채널');
+      voiceRedisRepository.getCategoryInfo.mockResolvedValue(null);
+
+      await service.flushDate(guild, user, date);
+
+      expect(voiceDailyRepository.accumulateChannelDuration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          autoChannelButtonId: null,
+          autoChannelButtonLabel: null,
+        }),
+      );
     });
   });
 });

--- a/apps/api/src/channel/voice/application/voice-daily-flush-service.ts
+++ b/apps/api/src/channel/voice/application/voice-daily-flush-service.ts
@@ -64,6 +64,8 @@ export class VoiceDailyFlushService {
         channelType: autoChannelInfo?.channelType ?? 'permanent',
         autoChannelConfigId: autoChannelInfo?.configId ?? null,
         autoChannelConfigName: autoChannelInfo?.configName ?? null,
+        autoChannelButtonId: autoChannelInfo?.buttonId ?? null,
+        autoChannelButtonLabel: autoChannelInfo?.buttonLabel ?? null,
       });
 
       await this.redis.del(key);

--- a/apps/api/src/channel/voice/application/voice-daily.service.spec.ts
+++ b/apps/api/src/channel/voice/application/voice-daily.service.spec.ts
@@ -24,6 +24,8 @@ function makeEntity(overrides: Partial<VoiceDailyOrm> = {}): VoiceDailyOrm {
     channelType: 'permanent',
     autoChannelConfigId: null,
     autoChannelConfigName: null,
+    autoChannelButtonId: null,
+    autoChannelButtonLabel: null,
     ...overrides,
   };
 }
@@ -123,6 +125,71 @@ describe('VoiceDailyService', () => {
       expect(result[0].userId).toBe('user-1');
       expect(result[1].userId).toBe('user-2');
       expect(result[1].channelDurationSec).toBe(7200);
+    });
+
+    it('autoChannelButtonId, autoChannelButtonLabel이 DTO에 포함된다', async () => {
+      const entity = makeEntity({
+        channelType: 'auto_select',
+        autoChannelConfigId: 1,
+        autoChannelConfigName: '게임방',
+        autoChannelButtonId: 10,
+        autoChannelButtonLabel: '오버워치',
+      });
+      voiceDailyRepository.findByGuildIdAndDateRange.mockResolvedValue([entity]);
+
+      const result = await service.getDailyRecords('guild-1', '20260301', '20260307');
+
+      expect(result[0].autoChannelButtonId).toBe(10);
+      expect(result[0].autoChannelButtonLabel).toBe('오버워치');
+    });
+
+    it('autoChannelButtonId=null, autoChannelButtonLabel=null이면 null로 변환된다', async () => {
+      const entity = makeEntity({
+        channelType: 'auto_instant',
+        autoChannelConfigId: 42,
+        autoChannelConfigName: '즉시생성방',
+        autoChannelButtonId: null,
+        autoChannelButtonLabel: null,
+      });
+      voiceDailyRepository.findByGuildIdAndDateRange.mockResolvedValue([entity]);
+
+      const result = await service.getDailyRecords('guild-1', '20260301', '20260307');
+
+      expect(result[0].autoChannelButtonId).toBeNull();
+      expect(result[0].autoChannelButtonLabel).toBeNull();
+    });
+
+    it('autoChannelButtonId, autoChannelButtonLabel이 undefined이면 null로 변환된다', async () => {
+      const entity = makeEntity({
+        autoChannelButtonId: undefined as unknown as null,
+        autoChannelButtonLabel: undefined as unknown as null,
+      });
+      voiceDailyRepository.findByGuildIdAndDateRange.mockResolvedValue([entity]);
+
+      const result = await service.getDailyRecords('guild-1', '20260301', '20260307');
+
+      expect(result[0].autoChannelButtonId).toBeNull();
+      expect(result[0].autoChannelButtonLabel).toBeNull();
+    });
+
+    it('channelType, autoChannelConfigId, autoChannelConfigName, autoChannelButtonId, autoChannelButtonLabel 필드가 모두 DTO에 포함된다', async () => {
+      const entity = makeEntity({
+        channelType: 'auto_select',
+        autoChannelConfigId: 7,
+        autoChannelConfigName: '스터디방',
+        autoChannelButtonId: 77,
+        autoChannelButtonLabel: '스터디',
+      });
+      voiceDailyRepository.findByGuildIdAndDateRange.mockResolvedValue([entity]);
+
+      const result = await service.getDailyRecords('guild-1', '20260301', '20260307');
+
+      const dto = result[0];
+      expect(dto.channelType).toBe('auto_select');
+      expect(dto.autoChannelConfigId).toBe(7);
+      expect(dto.autoChannelConfigName).toBe('스터디방');
+      expect(dto.autoChannelButtonId).toBe(77);
+      expect(dto.autoChannelButtonLabel).toBe('스터디');
     });
   });
 });

--- a/apps/api/src/channel/voice/application/voice-daily.service.ts
+++ b/apps/api/src/channel/voice/application/voice-daily.service.ts
@@ -37,6 +37,8 @@ export class VoiceDailyService {
       channelType: e.channelType ?? 'permanent',
       autoChannelConfigId: e.autoChannelConfigId ?? null,
       autoChannelConfigName: e.autoChannelConfigName ?? null,
+      autoChannelButtonId: e.autoChannelButtonId ?? null,
+      autoChannelButtonLabel: e.autoChannelButtonLabel ?? null,
     }));
   }
 }

--- a/apps/api/src/channel/voice/application/voice-recovery.service.spec.ts
+++ b/apps/api/src/channel/voice/application/voice-recovery.service.spec.ts
@@ -28,6 +28,8 @@ describe('VoiceRecoveryService', () => {
   };
   let flushService: { flushDate: Mock };
   let historyService: { closeOrphanRecords: Mock };
+  let voiceChannelService: { onUserJoined: Mock };
+  let excludedChannelService: { isExcludedChannel: Mock };
 
   beforeEach(() => {
     redis = {
@@ -48,11 +50,21 @@ describe('VoiceRecoveryService', () => {
       closeOrphanRecords: vi.fn().mockResolvedValue(undefined),
     };
 
+    voiceChannelService = {
+      onUserJoined: vi.fn().mockResolvedValue(undefined),
+    };
+
+    excludedChannelService = {
+      isExcludedChannel: vi.fn().mockResolvedValue(false),
+    };
+
     service = new VoiceRecoveryService(
       redis as never,
       voiceRedisRepository as never,
       flushService as never,
       historyService as never,
+      voiceChannelService as never,
+      excludedChannelService as never,
     );
 
     vi.clearAllMocks();
@@ -85,22 +97,22 @@ describe('VoiceRecoveryService', () => {
     });
   });
 
-  describe('onAppReady', () => {
+  describe('onApplicationBootstrap', () => {
     it('closeOrphanRecords와 recoverOrphanSessions(scanKeys)를 호출한다', async () => {
       redis.scanKeys.mockResolvedValue([]);
 
-      await service.onAppReady();
+      await service.onApplicationBootstrap();
 
       expect(historyService.closeOrphanRecords).toHaveBeenCalledTimes(1);
       expect(redis.scanKeys).toHaveBeenCalledWith('voice:session:*');
     });
   });
 
-  describe('recoverOrphanSessions (onAppReady를 통해 간접 테스트)', () => {
+  describe('recoverOrphanSessions (onApplicationBootstrap를 통해 간접 테스트)', () => {
     it('orphan 세션 없으면 accumulateDuration, flushDate, deleteSession 호출하지 않음', async () => {
       redis.scanKeys.mockResolvedValue([]);
 
-      await service.onAppReady();
+      await service.onApplicationBootstrap();
 
       expect(voiceRedisRepository.getSession).not.toHaveBeenCalled();
       expect(voiceRedisRepository.accumulateDuration).not.toHaveBeenCalled();
@@ -119,7 +131,7 @@ describe('VoiceRecoveryService', () => {
         .mockResolvedValueOnce(session1)
         .mockResolvedValueOnce(session2);
 
-      await service.onAppReady();
+      await service.onApplicationBootstrap();
 
       expect(voiceRedisRepository.accumulateDuration).toHaveBeenCalledTimes(2);
       expect(flushService.flushDate).toHaveBeenCalledWith('guild-1', 'user-1', '20260318');
@@ -138,7 +150,7 @@ describe('VoiceRecoveryService', () => {
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(validSession);
 
-      await service.onAppReady();
+      await service.onApplicationBootstrap();
 
       // null 세션은 skip, 유효한 세션만 처리
       expect(voiceRedisRepository.accumulateDuration).toHaveBeenCalledTimes(1);
@@ -161,7 +173,7 @@ describe('VoiceRecoveryService', () => {
         .mockRejectedValueOnce(new Error('flush failed'))
         .mockResolvedValueOnce(undefined);
 
-      await service.onAppReady();
+      await service.onApplicationBootstrap();
 
       // 첫 번째는 실패, 두 번째는 성공
       expect(flushService.flushDate).toHaveBeenCalledTimes(2);

--- a/apps/api/src/channel/voice/dto/voice-daily-record.dto.ts
+++ b/apps/api/src/channel/voice/dto/voice-daily-record.dto.ts
@@ -14,4 +14,6 @@ export class VoiceDailyRecordDto {
   channelType: 'permanent' | 'auto_select' | 'auto_instant';
   autoChannelConfigId: number | null;
   autoChannelConfigName: string | null;
+  autoChannelButtonId: number | null;
+  autoChannelButtonLabel: string | null;
 }

--- a/apps/api/src/channel/voice/infrastructure/voice-daily-auto-channel.spec.ts
+++ b/apps/api/src/channel/voice/infrastructure/voice-daily-auto-channel.spec.ts
@@ -115,7 +115,7 @@ describe('VoiceDailyRepository.accumulateChannelDuration — auto-channel 파라
       expect(params[12]).toBeNull();
     });
 
-    it('총 파라미터 개수가 13개다', async () => {
+    it('총 파라미터 개수가 15개다 (buttonId, buttonLabel 포함)', async () => {
       await repository.accumulateChannelDuration({
         guildId: 'guild-1',
         userId: 'user-1',
@@ -129,10 +129,12 @@ describe('VoiceDailyRepository.accumulateChannelDuration — auto-channel 파라
         channelType: 'auto_select',
         autoChannelConfigId: 1,
         autoChannelConfigName: '설정이름',
+        autoChannelButtonId: 10,
+        autoChannelButtonLabel: '버튼',
       });
 
       const [, params] = mockRepo.query.mock.calls[0] as [string, unknown[]];
-      expect(params).toHaveLength(13);
+      expect(params).toHaveLength(15);
     });
 
     it('SQL에 channelType, autoChannelConfigId, autoChannelConfigName 컬럼이 포함된다', async () => {
@@ -201,6 +203,119 @@ describe('VoiceDailyRepository.accumulateChannelDuration — auto-channel 파라
       // vd가 EXCLUDED보다 앞에 와야 한다 (기존 값 우선)
       const coalesceMatch = sql.match(
         /COALESCE\(vd\."autoChannelConfigId"\s*,\s*EXCLUDED\."autoChannelConfigId"\)/,
+      );
+      expect(coalesceMatch).not.toBeNull();
+    });
+
+    it('autoChannelButtonId, autoChannelButtonLabel을 전달하면 $14, $15 파라미터에 포함된다', async () => {
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        userName: 'Alice',
+        date: '20260316',
+        channelId: 'ch-1',
+        channelName: '게임방-1호',
+        durationSec: 300,
+        categoryId: null,
+        categoryName: null,
+        channelType: 'auto_select',
+        autoChannelConfigId: 1,
+        autoChannelConfigName: '게임방',
+        autoChannelButtonId: 10,
+        autoChannelButtonLabel: '오버워치',
+      });
+
+      const [, params] = mockRepo.query.mock.calls[0] as [string, unknown[]];
+      // $14 = autoChannelButtonId, $15 = autoChannelButtonLabel
+      expect(params[13]).toBe(10);
+      expect(params[14]).toBe('오버워치');
+    });
+
+    it('autoChannelButtonId=null, autoChannelButtonLabel=null이면 null이 파라미터에 전달된다', async () => {
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        userName: 'Alice',
+        date: '20260316',
+        channelId: 'ch-1',
+        channelName: '즉시방-1호',
+        durationSec: 600,
+        categoryId: null,
+        categoryName: null,
+        channelType: 'auto_instant',
+        autoChannelConfigId: 42,
+        autoChannelConfigName: '즉시생성방',
+        autoChannelButtonId: null,
+        autoChannelButtonLabel: null,
+      });
+
+      const [, params] = mockRepo.query.mock.calls[0] as [string, unknown[]];
+      expect(params[13]).toBeNull();
+      expect(params[14]).toBeNull();
+    });
+
+    it('autoChannelButtonId, autoChannelButtonLabel을 생략하면 기본값 null이 적용된다', async () => {
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        userName: 'Alice',
+        date: '20260316',
+        channelId: 'ch-1',
+        channelName: '채널',
+        durationSec: 100,
+        categoryId: null,
+        categoryName: null,
+      });
+
+      const [, params] = mockRepo.query.mock.calls[0] as [string, unknown[]];
+      expect(params[13]).toBeNull();
+      expect(params[14]).toBeNull();
+    });
+
+    it('SQL에 autoChannelButtonId, autoChannelButtonLabel 컬럼이 포함된다', async () => {
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        userName: 'Alice',
+        date: '20260316',
+        channelId: 'ch-1',
+        channelName: '채널',
+        durationSec: 100,
+        categoryId: null,
+        categoryName: null,
+        channelType: 'auto_select',
+        autoChannelConfigId: 1,
+        autoChannelConfigName: '방',
+        autoChannelButtonId: 10,
+        autoChannelButtonLabel: '버튼',
+      });
+
+      const [sql] = mockRepo.query.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain('"autoChannelButtonId"');
+      expect(sql).toContain('"autoChannelButtonLabel"');
+    });
+
+    it('SQL에 autoChannelButtonId COALESCE(vd, EXCLUDED) 패턴이 포함된다', async () => {
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        userName: 'Alice',
+        date: '20260316',
+        channelId: 'ch-1',
+        channelName: '채널',
+        durationSec: 100,
+        categoryId: null,
+        categoryName: null,
+        channelType: 'auto_select',
+        autoChannelConfigId: 1,
+        autoChannelConfigName: '방',
+        autoChannelButtonId: 10,
+        autoChannelButtonLabel: '버튼',
+      });
+
+      const [sql] = mockRepo.query.mock.calls[0] as [string, unknown[]];
+      const coalesceMatch = sql.match(
+        /COALESCE\(vd\."autoChannelButtonId"\s*,\s*EXCLUDED\."autoChannelButtonId"\)/,
       );
       expect(coalesceMatch).not.toBeNull();
     });

--- a/apps/api/src/channel/voice/infrastructure/voice-daily.orm-entity.ts
+++ b/apps/api/src/channel/voice/infrastructure/voice-daily.orm-entity.ts
@@ -61,4 +61,10 @@ export class VoiceDailyOrm {
 
   @Column({ type: 'varchar', length: 255, nullable: true })
   autoChannelConfigName: string | null;
+
+  @Column({ type: 'int', nullable: true })
+  autoChannelButtonId: number | null;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  autoChannelButtonLabel: string | null;
 }

--- a/apps/api/src/channel/voice/infrastructure/voice-daily.repository.integration-spec.ts
+++ b/apps/api/src/channel/voice/infrastructure/voice-daily.repository.integration-spec.ts
@@ -28,17 +28,17 @@ describe('VoiceDailyRepository (Integration)', () => {
 
   describe('accumulateChannelDuration', () => {
     it('신규 레코드를 INSERT한다', async () => {
-      await repository.accumulateChannelDuration(
-        'guild-1',
-        'user-1',
-        'Alice',
-        '20260318',
-        'ch-1',
-        'General',
-        300,
-        null,
-        null,
-      );
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        userName: 'Alice',
+        date: '20260318',
+        channelId: 'ch-1',
+        channelName: 'General',
+        durationSec: 300,
+        categoryId: null,
+        categoryName: null,
+      });
 
       const result = await dataSource.getRepository(VoiceDailyOrm).findOneBy({
         guildId: 'guild-1',
@@ -53,28 +53,28 @@ describe('VoiceDailyRepository (Integration)', () => {
     });
 
     it('기존 레코드에 duration을 누적한다', async () => {
-      await repository.accumulateChannelDuration(
-        'guild-1',
-        'user-1',
-        'Alice',
-        '20260318',
-        'ch-1',
-        'General',
-        300,
-        null,
-        null,
-      );
-      await repository.accumulateChannelDuration(
-        'guild-1',
-        'user-1',
-        'Alice',
-        '20260318',
-        'ch-1',
-        'General',
-        200,
-        null,
-        null,
-      );
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        userName: 'Alice',
+        date: '20260318',
+        channelId: 'ch-1',
+        channelName: 'General',
+        durationSec: 300,
+        categoryId: null,
+        categoryName: null,
+      });
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        userName: 'Alice',
+        date: '20260318',
+        channelId: 'ch-1',
+        channelName: 'General',
+        durationSec: 200,
+        categoryId: null,
+        categoryName: null,
+      });
 
       const result = await dataSource.getRepository(VoiceDailyOrm).findOneBy({
         guildId: 'guild-1',
@@ -86,28 +86,28 @@ describe('VoiceDailyRepository (Integration)', () => {
     });
 
     it('다른 채널은 별도 레코드로 저장한다', async () => {
-      await repository.accumulateChannelDuration(
-        'guild-1',
-        'user-1',
-        'Alice',
-        '20260318',
-        'ch-1',
-        'General',
-        300,
-        null,
-        null,
-      );
-      await repository.accumulateChannelDuration(
-        'guild-1',
-        'user-1',
-        'Alice',
-        '20260318',
-        'ch-2',
-        'Gaming',
-        150,
-        'cat-1',
-        'Voice',
-      );
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        userName: 'Alice',
+        date: '20260318',
+        channelId: 'ch-1',
+        channelName: 'General',
+        durationSec: 300,
+        categoryId: null,
+        categoryName: null,
+      });
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        userName: 'Alice',
+        date: '20260318',
+        channelId: 'ch-2',
+        channelName: 'Gaming',
+        durationSec: 150,
+        categoryId: 'cat-1',
+        categoryName: 'Voice',
+      });
 
       const records = await dataSource.getRepository(VoiceDailyOrm).findBy({
         guildId: 'guild-1',
@@ -136,39 +136,39 @@ describe('VoiceDailyRepository (Integration)', () => {
 
   describe('findByGuildIdAndDateRange', () => {
     it('날짜 범위로 레코드를 조회한다', async () => {
-      await repository.accumulateChannelDuration(
-        'guild-1',
-        'user-1',
-        'Alice',
-        '20260317',
-        'ch-1',
-        'General',
-        100,
-        null,
-        null,
-      );
-      await repository.accumulateChannelDuration(
-        'guild-1',
-        'user-1',
-        'Alice',
-        '20260318',
-        'ch-1',
-        'General',
-        200,
-        null,
-        null,
-      );
-      await repository.accumulateChannelDuration(
-        'guild-1',
-        'user-1',
-        'Alice',
-        '20260319',
-        'ch-1',
-        'General',
-        300,
-        null,
-        null,
-      );
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        userName: 'Alice',
+        date: '20260317',
+        channelId: 'ch-1',
+        channelName: 'General',
+        durationSec: 100,
+        categoryId: null,
+        categoryName: null,
+      });
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        userName: 'Alice',
+        date: '20260318',
+        channelId: 'ch-1',
+        channelName: 'General',
+        durationSec: 200,
+        categoryId: null,
+        categoryName: null,
+      });
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        userName: 'Alice',
+        date: '20260319',
+        channelId: 'ch-1',
+        channelName: 'General',
+        durationSec: 300,
+        categoryId: null,
+        categoryName: null,
+      });
 
       const results = await repository.findByGuildIdAndDateRange('guild-1', '20260317', '20260318');
 
@@ -176,28 +176,28 @@ describe('VoiceDailyRepository (Integration)', () => {
     });
 
     it('userId를 지정하면 해당 유저만 조회한다', async () => {
-      await repository.accumulateChannelDuration(
-        'guild-1',
-        'user-1',
-        'Alice',
-        '20260318',
-        'ch-1',
-        'General',
-        100,
-        null,
-        null,
-      );
-      await repository.accumulateChannelDuration(
-        'guild-1',
-        'user-2',
-        'Bob',
-        '20260318',
-        'ch-1',
-        'General',
-        200,
-        null,
-        null,
-      );
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-1',
+        userName: 'Alice',
+        date: '20260318',
+        channelId: 'ch-1',
+        channelName: 'General',
+        durationSec: 100,
+        categoryId: null,
+        categoryName: null,
+      });
+      await repository.accumulateChannelDuration({
+        guildId: 'guild-1',
+        userId: 'user-2',
+        userName: 'Bob',
+        date: '20260318',
+        channelId: 'ch-1',
+        channelName: 'General',
+        durationSec: 200,
+        categoryId: null,
+        categoryName: null,
+      });
 
       const results = await repository.findByGuildIdAndDateRange(
         'guild-1',

--- a/apps/api/src/channel/voice/infrastructure/voice-daily.repository.ts
+++ b/apps/api/src/channel/voice/infrastructure/voice-daily.repository.ts
@@ -19,6 +19,8 @@ interface AccumulateChannelDurationParams {
   channelType?: ChannelType;
   autoChannelConfigId?: number | null;
   autoChannelConfigName?: string | null;
+  autoChannelButtonId?: number | null;
+  autoChannelButtonLabel?: string | null;
 }
 
 @Injectable()
@@ -49,14 +51,16 @@ export class VoiceDailyRepository {
       channelType = 'permanent',
       autoChannelConfigId = null,
       autoChannelConfigName = null,
+      autoChannelButtonId = null,
+      autoChannelButtonLabel = null,
     } = params;
     const recordedAt = this.dateToRecordedAt(date);
     await this.repo.query(
       `
       INSERT INTO voice_daily AS vd
           ("guildId","userId","userName","date","channelId","channelName","channelDurationSec","categoryId","categoryName","recordedAt",
-           "channelType","autoChannelConfigId","autoChannelConfigName")
-      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+           "channelType","autoChannelConfigId","autoChannelConfigName","autoChannelButtonId","autoChannelButtonLabel")
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
       ON CONFLICT ("guildId","userId","date","channelId")
       DO UPDATE SET
         "channelDurationSec" =
@@ -71,7 +75,9 @@ export class VoiceDailyRepository {
           ELSE EXCLUDED."channelType"
         END,
         "autoChannelConfigId"   = COALESCE(vd."autoChannelConfigId",   EXCLUDED."autoChannelConfigId"),
-        "autoChannelConfigName" = COALESCE(vd."autoChannelConfigName", EXCLUDED."autoChannelConfigName")
+        "autoChannelConfigName" = COALESCE(vd."autoChannelConfigName", EXCLUDED."autoChannelConfigName"),
+        "autoChannelButtonId"    = COALESCE(vd."autoChannelButtonId",   EXCLUDED."autoChannelButtonId"),
+        "autoChannelButtonLabel" = COALESCE(vd."autoChannelButtonLabel", EXCLUDED."autoChannelButtonLabel")
       `,
       [
         guildId,
@@ -87,6 +93,8 @@ export class VoiceDailyRepository {
         channelType,
         autoChannelConfigId,
         autoChannelConfigName,
+        autoChannelButtonId,
+        autoChannelButtonLabel,
       ],
     );
   }

--- a/apps/api/src/channel/voice/infrastructure/voice-redis-auto-channel.spec.ts
+++ b/apps/api/src/channel/voice/infrastructure/voice-redis-auto-channel.spec.ts
@@ -29,6 +29,8 @@ describe('VoiceRedisRepository — autoChannelInfo 캐시', () => {
         configId: 1,
         configName: '게임방',
         channelType: 'auto_select',
+        buttonId: 10,
+        buttonLabel: '게임',
       };
 
       await repo.setAutoChannelInfo(guild, channelId, info);
@@ -42,6 +44,8 @@ describe('VoiceRedisRepository — autoChannelInfo 캐시', () => {
         configId: 42,
         configName: '즉시생성방',
         channelType: 'auto_instant',
+        buttonId: null,
+        buttonLabel: null,
       };
 
       await repo.setAutoChannelInfo(guild, channelId, info);
@@ -61,6 +65,8 @@ describe('VoiceRedisRepository — autoChannelInfo 캐시', () => {
         configId: 1,
         configName: '테스트방',
         channelType: 'auto_select',
+        buttonId: 5,
+        buttonLabel: '테스트',
       };
 
       await repo.setAutoChannelInfo(guild, channelId, info);
@@ -72,11 +78,19 @@ describe('VoiceRedisRepository — autoChannelInfo 캐시', () => {
     });
 
     it('다른 채널의 메타데이터는 서로 독립적이다', async () => {
-      const info1: AutoChannelInfo = { configId: 1, configName: '방1', channelType: 'auto_select' };
+      const info1: AutoChannelInfo = {
+        configId: 1,
+        configName: '방1',
+        channelType: 'auto_select',
+        buttonId: 1,
+        buttonLabel: '방1',
+      };
       const info2: AutoChannelInfo = {
         configId: 2,
         configName: '방2',
         channelType: 'auto_instant',
+        buttonId: null,
+        buttonLabel: null,
       };
 
       await repo.setAutoChannelInfo(guild, 'ch-1', info1);
@@ -94,6 +108,8 @@ describe('VoiceRedisRepository — autoChannelInfo 캐시', () => {
         configId: 99,
         configName: '공통방',
         channelType: 'auto_select',
+        buttonId: 99,
+        buttonLabel: '공통',
       };
 
       await repo.setAutoChannelInfo('guild-A', channelId, info);
@@ -102,11 +118,13 @@ describe('VoiceRedisRepository — autoChannelInfo 캐시', () => {
       expect(resultOtherGuild).toBeNull();
     });
 
-    it('configId, configName, channelType 필드가 모두 보존된다', async () => {
+    it('configId, configName, channelType, buttonId, buttonLabel 필드가 모두 보존된다', async () => {
       const info: AutoChannelInfo = {
         configId: 7,
         configName: '스터디방',
         channelType: 'auto_select',
+        buttonId: 7,
+        buttonLabel: '스터디',
       };
 
       await repo.setAutoChannelInfo(guild, channelId, info);
@@ -115,6 +133,8 @@ describe('VoiceRedisRepository — autoChannelInfo 캐시', () => {
       expect(result?.configId).toBe(7);
       expect(result?.configName).toBe('스터디방');
       expect(result?.channelType).toBe('auto_select');
+      expect(result?.buttonId).toBe(7);
+      expect(result?.buttonLabel).toBe('스터디');
     });
 
     it('덮어쓰기(overwrite)하면 최신 값으로 조회된다', async () => {
@@ -122,11 +142,15 @@ describe('VoiceRedisRepository — autoChannelInfo 캐시', () => {
         configId: 1,
         configName: '구버전',
         channelType: 'auto_select',
+        buttonId: 1,
+        buttonLabel: '구버전',
       };
       const infoV2: AutoChannelInfo = {
         configId: 1,
         configName: '신버전',
         channelType: 'auto_select',
+        buttonId: 1,
+        buttonLabel: '신버전',
       };
 
       await repo.setAutoChannelInfo(guild, channelId, infoV1);

--- a/apps/api/src/channel/voice/infrastructure/voice-redis.repository.ts
+++ b/apps/api/src/channel/voice/infrastructure/voice-redis.repository.ts
@@ -9,6 +9,8 @@ export interface AutoChannelInfo {
   configId: number;
   configName: string;
   channelType: 'auto_select' | 'auto_instant';
+  buttonId: number | null;
+  buttonLabel: string | null;
 }
 
 /** Redis TTL 상수 (초 단위) */

--- a/apps/api/src/migrations/1776500000000-AddAutoChannelButtonGrouping.ts
+++ b/apps/api/src/migrations/1776500000000-AddAutoChannelButtonGrouping.ts
@@ -1,0 +1,23 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddAutoChannelButtonGrouping1776500000000 implements MigrationInterface {
+  name = 'AddAutoChannelButtonGrouping1776500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "voice_daily" ADD COLUMN "autoChannelButtonId" integer`);
+    await queryRunner.query(
+      `ALTER TABLE "voice_daily" ADD COLUMN "autoChannelButtonLabel" character varying(255)`,
+    );
+
+    // 버튼 단위 그룹핑 조회 최적화 (partial index)
+    await queryRunner.query(
+      `CREATE INDEX "IDX_voice_daily_auto_button" ON "voice_daily" ("guildId", "autoChannelButtonId", "date") WHERE "autoChannelButtonId" IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_voice_daily_auto_button"`);
+    await queryRunner.query(`ALTER TABLE "voice_daily" DROP COLUMN "autoChannelButtonLabel"`);
+    await queryRunner.query(`ALTER TABLE "voice_daily" DROP COLUMN "autoChannelButtonId"`);
+  }
+}

--- a/apps/api/src/newbie/application/mission/mission.service.spec.ts
+++ b/apps/api/src/newbie/application/mission/mission.service.spec.ts
@@ -80,6 +80,23 @@ function makeMission(overrides: Partial<NewbieMission> = {}): NewbieMission {
   };
 }
 
+/** 완전한 체이닝을 지원하는 QueryBuilder mock 생성 유틸리티 */
+function makeQb(rawResult: unknown = null) {
+  const qb: Record<string, Mock> = {};
+  const chain = () => qb as never;
+  qb.select = vi.fn().mockReturnValue(chain());
+  qb.where = vi.fn().mockReturnValue(chain());
+  qb.andWhere = vi.fn().mockReturnValue(chain());
+  qb.from = vi.fn().mockReturnValue(chain());
+  qb.innerJoin = vi.fn().mockReturnValue(chain());
+  qb.orderBy = vi.fn().mockReturnValue(chain());
+  qb.limit = vi.fn().mockReturnValue(chain());
+  qb.getRawOne = vi.fn().mockResolvedValue(rawResult);
+  qb.getRawMany = vi.fn().mockResolvedValue([]);
+  qb.getMany = vi.fn().mockResolvedValue([]);
+  return qb;
+}
+
 describe('MissionService', () => {
   let service: MissionService;
   let missionRepo: {
@@ -113,6 +130,7 @@ describe('MissionService', () => {
   };
   let renderer: Mocked<MissionRankRenderer>;
   let redis: Mocked<RedisService>;
+  let guildMemberService: { findByUserId: Mock };
   let voiceDailyRepo: { createQueryBuilder: Mock };
   let voiceHistoryRepo: { createQueryBuilder: Mock };
 
@@ -141,7 +159,11 @@ describe('MissionService', () => {
     };
     renderer = {
       renderPage: vi.fn().mockResolvedValue(Buffer.from('fake-png-data')),
+      renderAll: vi.fn().mockResolvedValue(Buffer.from('fake-png-data')),
     } as unknown as Mocked<MissionRankRenderer>;
+    guildMemberService = {
+      findByUserId: vi.fn().mockResolvedValue(null),
+    };
     redis = {
       getBuffer: vi.fn().mockResolvedValue(null),
       setBuffer: vi.fn().mockResolvedValue(undefined),
@@ -153,23 +175,6 @@ describe('MissionService', () => {
       fetchMemberDisplayName: vi.fn(),
       checkMemberExists: vi.fn(),
       fetchGuildMembers: vi.fn(),
-    };
-
-    // createQueryBuilder 체이닝 mock
-    const makeQb = (rawResult: unknown) => {
-      const qb: Record<string, Mock> = {};
-      const chain = () => qb as unknown as ReturnType<typeof makeQb>;
-      qb.select = vi.fn().mockReturnValue(chain());
-      qb.where = vi.fn().mockReturnValue(chain());
-      qb.andWhere = vi.fn().mockReturnValue(chain());
-      qb.from = vi.fn().mockReturnValue(chain());
-      qb.innerJoin = vi.fn().mockReturnValue(chain());
-      qb.orderBy = vi.fn().mockReturnValue(chain());
-      qb.limit = vi.fn().mockReturnValue(chain());
-      qb.getRawOne = vi.fn().mockResolvedValue(rawResult);
-      qb.getRawMany = vi.fn().mockResolvedValue([]);
-      qb.getMany = vi.fn().mockResolvedValue([]);
-      return qb;
     };
 
     voiceDailyRepo = {
@@ -188,6 +193,7 @@ describe('MissionService', () => {
       discordAction as never,
       renderer as never,
       redis as never,
+      guildMemberService as never,
       voiceDailyRepo as never,
       voiceHistoryRepo as never,
     );
@@ -415,13 +421,7 @@ describe('MissionService', () => {
   // ──────────────────────────────────────────────────────
   describe('getPlaytimeSec', () => {
     it('GLOBAL channelId를 제외하고 채널별 시간을 합산한다', async () => {
-      const qb: Record<string, Mock> = {};
-      const self = () => qb as never;
-      qb.select = vi.fn().mockReturnValue(self());
-      qb.where = vi.fn().mockReturnValue(self());
-      qb.andWhere = vi.fn().mockReturnValue(self());
-      qb.getRawOne = vi.fn().mockResolvedValue({ total: '3600' });
-
+      const qb = makeQb({ total: '3600' });
       voiceDailyRepo.createQueryBuilder.mockReturnValue(qb);
 
       const result = await service.getPlaytimeSec('guild-1', 'user-1', '20260301', '20260308');
@@ -435,13 +435,7 @@ describe('MissionService', () => {
     });
 
     it('데이터가 없으면 0 반환', async () => {
-      const qb: Record<string, Mock> = {};
-      const self = () => qb as never;
-      qb.select = vi.fn().mockReturnValue(self());
-      qb.where = vi.fn().mockReturnValue(self());
-      qb.andWhere = vi.fn().mockReturnValue(self());
-      qb.getRawOne = vi.fn().mockResolvedValue(null);
-
+      const qb = makeQb(null);
       voiceDailyRepo.createQueryBuilder.mockReturnValue(qb);
 
       const result = await service.getPlaytimeSec('guild-1', 'user-1', '20260301', '20260308');
@@ -457,20 +451,10 @@ describe('MissionService', () => {
     it('playCountMinDurationMin, playCountIntervalMin 모두 null이면 세션 수 그대로 반환', async () => {
       const config = makeConfig({ playCountMinDurationMin: null, playCountIntervalMin: null });
 
-      const distinctQb: Record<string, Mock> = {};
-      const dSelf = () => distinctQb as never;
-      distinctQb.select = vi.fn().mockReturnValue(dSelf());
-      distinctQb.where = vi.fn().mockReturnValue(dSelf());
-      distinctQb.andWhere = vi.fn().mockReturnValue(dSelf());
+      const distinctQb = makeQb(null);
       distinctQb.getRawMany = vi.fn().mockResolvedValue([{ channelId: 'ch-1' }]);
 
-      const historyQb: Record<string, Mock> = {};
-      const hSelf = () => historyQb as never;
-      historyQb.select = vi.fn().mockReturnValue(hSelf());
-      historyQb.innerJoin = vi.fn().mockReturnValue(hSelf());
-      historyQb.where = vi.fn().mockReturnValue(hSelf());
-      historyQb.andWhere = vi.fn().mockReturnValue(hSelf());
-      historyQb.orderBy = vi.fn().mockReturnValue(hSelf());
+      const historyQb = makeQb(null);
       historyQb.getMany = vi.fn().mockResolvedValue([
         { joinedAt: new Date('2026-03-01T10:00:00Z'), leftAt: new Date('2026-03-01T10:30:00Z') },
         { joinedAt: new Date('2026-03-01T12:00:00Z'), leftAt: new Date('2026-03-01T12:30:00Z') },
@@ -493,11 +477,7 @@ describe('MissionService', () => {
     it('guildChannelIds가 비어있으면 0 반환', async () => {
       const config = makeConfig({ playCountMinDurationMin: null, playCountIntervalMin: null });
 
-      const distinctQb: Record<string, Mock> = {};
-      const dSelf = () => distinctQb as never;
-      distinctQb.select = vi.fn().mockReturnValue(dSelf());
-      distinctQb.where = vi.fn().mockReturnValue(dSelf());
-      distinctQb.andWhere = vi.fn().mockReturnValue(dSelf());
+      const distinctQb = makeQb(null);
       distinctQb.getRawMany = vi.fn().mockResolvedValue([]); // 빈 채널 목록
 
       voiceDailyRepo.createQueryBuilder.mockReturnValue(distinctQb);
@@ -516,20 +496,10 @@ describe('MissionService', () => {
     it('playCountMinDurationMin 필터: 최소 지속시간 미만 세션 제외', async () => {
       const config = makeConfig({ playCountMinDurationMin: 30, playCountIntervalMin: null });
 
-      const distinctQb: Record<string, Mock> = {};
-      const dSelf = () => distinctQb as never;
-      distinctQb.select = vi.fn().mockReturnValue(dSelf());
-      distinctQb.where = vi.fn().mockReturnValue(dSelf());
-      distinctQb.andWhere = vi.fn().mockReturnValue(dSelf());
+      const distinctQb = makeQb(null);
       distinctQb.getRawMany = vi.fn().mockResolvedValue([{ channelId: 'ch-1' }]);
 
-      const historyQb: Record<string, Mock> = {};
-      const hSelf = () => historyQb as never;
-      historyQb.select = vi.fn().mockReturnValue(hSelf());
-      historyQb.innerJoin = vi.fn().mockReturnValue(hSelf());
-      historyQb.where = vi.fn().mockReturnValue(hSelf());
-      historyQb.andWhere = vi.fn().mockReturnValue(hSelf());
-      historyQb.orderBy = vi.fn().mockReturnValue(hSelf());
+      const historyQb = makeQb(null);
       // 10분짜리(600000ms < 30분) 세션 → 필터 제외
       // 60분짜리(3600000ms >= 30분) 세션 → 포함
       historyQb.getMany = vi.fn().mockResolvedValue([
@@ -560,20 +530,10 @@ describe('MissionService', () => {
     it('playCountIntervalMin 필터: 간격 이내 세션 묶음 처리', async () => {
       const config = makeConfig({ playCountMinDurationMin: null, playCountIntervalMin: 60 });
 
-      const distinctQb: Record<string, Mock> = {};
-      const dSelf = () => distinctQb as never;
-      distinctQb.select = vi.fn().mockReturnValue(dSelf());
-      distinctQb.where = vi.fn().mockReturnValue(dSelf());
-      distinctQb.andWhere = vi.fn().mockReturnValue(dSelf());
+      const distinctQb = makeQb(null);
       distinctQb.getRawMany = vi.fn().mockResolvedValue([{ channelId: 'ch-1' }]);
 
-      const historyQb: Record<string, Mock> = {};
-      const hSelf = () => historyQb as never;
-      historyQb.select = vi.fn().mockReturnValue(hSelf());
-      historyQb.innerJoin = vi.fn().mockReturnValue(hSelf());
-      historyQb.where = vi.fn().mockReturnValue(hSelf());
-      historyQb.andWhere = vi.fn().mockReturnValue(hSelf());
-      historyQb.orderBy = vi.fn().mockReturnValue(hSelf());
+      const historyQb = makeQb(null);
       // 10:00, 10:30, 13:00 → 10:00~10:30 묶음(1) + 13:00 별도(2) = 2
       historyQb.getMany = vi.fn().mockResolvedValue([
         { joinedAt: new Date('2026-03-01T10:00:00Z'), leftAt: new Date('2026-03-01T10:30:00Z') },
@@ -653,12 +613,7 @@ describe('MissionService', () => {
       const mission = makeMission();
       presenter.fetchMemberDisplayName.mockResolvedValue('동현');
 
-      const qb: Record<string, Mock> = {};
-      const self = () => qb as never;
-      qb.select = vi.fn().mockReturnValue(self());
-      qb.where = vi.fn().mockReturnValue(self());
-      qb.andWhere = vi.fn().mockReturnValue(self());
-      qb.getRawOne = vi.fn().mockResolvedValue({ total: '7200' });
+      const qb = makeQb({ total: '7200' });
       voiceDailyRepo.createQueryBuilder.mockReturnValue(qb);
 
       const result = await service.enrichMissions('guild-1', [mission]);
@@ -678,13 +633,7 @@ describe('MissionService', () => {
       presenter.fetchMemberDisplayName.mockResolvedValue('새닉네임');
       missionRepo.updateMemberName.mockResolvedValue(undefined);
 
-      const qb: Record<string, Mock> = {};
-      const self = () => qb as never;
-      qb.select = vi.fn().mockReturnValue(self());
-      qb.where = vi.fn().mockReturnValue(self());
-      qb.andWhere = vi.fn().mockReturnValue(self());
-      qb.getRawOne = vi.fn().mockResolvedValue({ total: '0' });
-      voiceDailyRepo.createQueryBuilder.mockReturnValue(qb);
+      voiceDailyRepo.createQueryBuilder.mockReturnValue(makeQb({ total: '0' }));
 
       const result = await service.enrichMissions('guild-1', [mission]);
 
@@ -696,13 +645,7 @@ describe('MissionService', () => {
       const mission = makeMission({ memberName: '동현' });
       presenter.fetchMemberDisplayName.mockResolvedValue('동현');
 
-      const qb: Record<string, Mock> = {};
-      const self = () => qb as never;
-      qb.select = vi.fn().mockReturnValue(self());
-      qb.where = vi.fn().mockReturnValue(self());
-      qb.andWhere = vi.fn().mockReturnValue(self());
-      qb.getRawOne = vi.fn().mockResolvedValue({ total: '0' });
-      voiceDailyRepo.createQueryBuilder.mockReturnValue(qb);
+      voiceDailyRepo.createQueryBuilder.mockReturnValue(makeQb({ total: '0' }));
 
       await service.enrichMissions('guild-1', [mission]);
 
@@ -717,13 +660,7 @@ describe('MissionService', () => {
     it('memberName이 있으면 Discord API를 호출하지 않고 DB 값을 사용한다', async () => {
       const mission = makeMission({ status: MissionStatus.COMPLETED, memberName: '저장된이름' });
 
-      const qb: Record<string, Mock> = {};
-      const self = () => qb as never;
-      qb.select = vi.fn().mockReturnValue(self());
-      qb.where = vi.fn().mockReturnValue(self());
-      qb.andWhere = vi.fn().mockReturnValue(self());
-      qb.getRawOne = vi.fn().mockResolvedValue({ total: '3600' });
-      voiceDailyRepo.createQueryBuilder.mockReturnValue(qb);
+      voiceDailyRepo.createQueryBuilder.mockReturnValue(makeQb({ total: '3600' }));
 
       const result = await service.enrichHistoryMissions('guild-1', [mission]);
 
@@ -737,13 +674,7 @@ describe('MissionService', () => {
       (presenter as unknown as Record<string, unknown>)['fetchMemberNickname'] = mockFetchNickname;
       missionRepo.updateMemberName.mockResolvedValue(undefined);
 
-      const qb: Record<string, Mock> = {};
-      const self = () => qb as never;
-      qb.select = vi.fn().mockReturnValue(self());
-      qb.where = vi.fn().mockReturnValue(self());
-      qb.andWhere = vi.fn().mockReturnValue(self());
-      qb.getRawOne = vi.fn().mockResolvedValue({ total: '0' });
-      voiceDailyRepo.createQueryBuilder.mockReturnValue(qb);
+      voiceDailyRepo.createQueryBuilder.mockReturnValue(makeQb({ total: '0' }));
 
       const result = await service.enrichHistoryMissions('guild-1', [mission]);
 
@@ -758,13 +689,7 @@ describe('MissionService', () => {
       const mockFetchNickname = vi.fn().mockResolvedValue(null);
       (presenter as unknown as Record<string, unknown>)['fetchMemberNickname'] = mockFetchNickname;
 
-      const qb: Record<string, Mock> = {};
-      const self = () => qb as never;
-      qb.select = vi.fn().mockReturnValue(self());
-      qb.where = vi.fn().mockReturnValue(self());
-      qb.andWhere = vi.fn().mockReturnValue(self());
-      qb.getRawOne = vi.fn().mockResolvedValue({ total: '0' });
-      voiceDailyRepo.createQueryBuilder.mockReturnValue(qb);
+      voiceDailyRepo.createQueryBuilder.mockReturnValue(makeQb({ total: '0' }));
 
       const result = await service.enrichHistoryMissions('guild-1', [mission]);
 
@@ -791,15 +716,8 @@ describe('MissionService', () => {
       missionRepo.updateStatus.mockResolvedValue(undefined);
       makeInvalidateSetup();
 
-      // playtimeSec = 10800 (목표 달성)
-      const qb: Record<string, Mock> = {};
-      const self = () => qb as never;
-      qb.select = vi.fn().mockReturnValue(self());
-      qb.where = vi.fn().mockReturnValue(self());
-      qb.andWhere = vi.fn().mockReturnValue(self());
-      qb.getRawOne = vi.fn().mockResolvedValue({ total: '10800' });
-      qb.getRawMany = vi.fn().mockResolvedValue([]);
-      voiceDailyRepo.createQueryBuilder.mockReturnValue(qb);
+      // targetPlayCount = null → getPlaytimeSec만 호출 (voiceDailyRepo 1회)
+      voiceDailyRepo.createQueryBuilder.mockReturnValue(makeQb({ total: '10800' }));
 
       await service.invalidateAndRefresh('guild-1');
 
@@ -814,14 +732,7 @@ describe('MissionService', () => {
       makeInvalidateSetup();
 
       // playtimeSec = 3600 (목표 미달)
-      const qb: Record<string, Mock> = {};
-      const self = () => qb as never;
-      qb.select = vi.fn().mockReturnValue(self());
-      qb.where = vi.fn().mockReturnValue(self());
-      qb.andWhere = vi.fn().mockReturnValue(self());
-      qb.getRawOne = vi.fn().mockResolvedValue({ total: '3600' });
-      qb.getRawMany = vi.fn().mockResolvedValue([]);
-      voiceDailyRepo.createQueryBuilder.mockReturnValue(qb);
+      voiceDailyRepo.createQueryBuilder.mockReturnValue(makeQb({ total: '3600' }));
 
       await service.invalidateAndRefresh('guild-1');
 
@@ -840,24 +751,15 @@ describe('MissionService', () => {
       missionRepo.updateStatus.mockResolvedValue(undefined);
       makeInvalidateSetup();
 
-      // voiceDailyRepo: playtimeSec 조회(getRawOne) + distinct channel 조회(getRawMany)
-      // voiceHistoryRepo: 세션 조회(getMany)
-      const dailyQb: Record<string, Mock> = {};
-      const dSelf = () => dailyQb as never;
-      dailyQb.select = vi.fn().mockReturnValue(dSelf());
-      dailyQb.where = vi.fn().mockReturnValue(dSelf());
-      dailyQb.andWhere = vi.fn().mockReturnValue(dSelf());
-      dailyQb.getRawOne = vi.fn().mockResolvedValue({ total: '10800' });
-      dailyQb.getRawMany = vi.fn().mockResolvedValue([{ channelId: 'ch-1' }]);
-      voiceDailyRepo.createQueryBuilder.mockReturnValue(dailyQb);
+      // voiceDailyRepo: 1번째 호출(getPlaytimeSec) → getRawOne, 2번째 호출(getPlayCount) → getRawMany
+      const playtimeQb = makeQb({ total: '10800' });
+      const distinctQb = makeQb(null);
+      distinctQb.getRawMany = vi.fn().mockResolvedValue([{ channelId: 'ch-1' }]);
+      voiceDailyRepo.createQueryBuilder
+        .mockReturnValueOnce(playtimeQb)
+        .mockReturnValueOnce(distinctQb);
 
-      const historyQb: Record<string, Mock> = {};
-      const hSelf = () => historyQb as never;
-      historyQb.select = vi.fn().mockReturnValue(hSelf());
-      historyQb.innerJoin = vi.fn().mockReturnValue(hSelf());
-      historyQb.where = vi.fn().mockReturnValue(hSelf());
-      historyQb.andWhere = vi.fn().mockReturnValue(hSelf());
-      historyQb.orderBy = vi.fn().mockReturnValue(hSelf());
+      const historyQb = makeQb(null);
       // playCount = 3 (목표 달성)
       historyQb.getMany = vi.fn().mockResolvedValue([
         { joinedAt: new Date('2026-03-01T10:00:00Z'), leftAt: new Date('2026-03-01T10:30:00Z') },
@@ -880,22 +782,15 @@ describe('MissionService', () => {
       missionRepo.updateStatus.mockResolvedValue(undefined);
       makeInvalidateSetup();
 
-      const dailyQb: Record<string, Mock> = {};
-      const dSelf = () => dailyQb as never;
-      dailyQb.select = vi.fn().mockReturnValue(dSelf());
-      dailyQb.where = vi.fn().mockReturnValue(dSelf());
-      dailyQb.andWhere = vi.fn().mockReturnValue(dSelf());
-      dailyQb.getRawOne = vi.fn().mockResolvedValue({ total: '10800' });
-      dailyQb.getRawMany = vi.fn().mockResolvedValue([{ channelId: 'ch-1' }]);
-      voiceDailyRepo.createQueryBuilder.mockReturnValue(dailyQb);
+      // voiceDailyRepo: 1번째 호출(getPlaytimeSec) → getRawOne, 2번째 호출(getPlayCount) → getRawMany
+      const playtimeQb = makeQb({ total: '10800' });
+      const distinctQb = makeQb(null);
+      distinctQb.getRawMany = vi.fn().mockResolvedValue([{ channelId: 'ch-1' }]);
+      voiceDailyRepo.createQueryBuilder
+        .mockReturnValueOnce(playtimeQb)
+        .mockReturnValueOnce(distinctQb);
 
-      const historyQb: Record<string, Mock> = {};
-      const hSelf = () => historyQb as never;
-      historyQb.select = vi.fn().mockReturnValue(hSelf());
-      historyQb.innerJoin = vi.fn().mockReturnValue(hSelf());
-      historyQb.where = vi.fn().mockReturnValue(hSelf());
-      historyQb.andWhere = vi.fn().mockReturnValue(hSelf());
-      historyQb.orderBy = vi.fn().mockReturnValue(hSelf());
+      const historyQb = makeQb(null);
       // playCount = 2 (목표 미달: 5 필요)
       historyQb.getMany = vi.fn().mockResolvedValue([
         { joinedAt: new Date('2026-03-01T10:00:00Z'), leftAt: new Date('2026-03-01T10:30:00Z') },
@@ -918,15 +813,8 @@ describe('MissionService', () => {
       missionRepo.updateStatus.mockResolvedValue(undefined);
       makeInvalidateSetup();
 
-      // playtimeSec 미달
-      const qb: Record<string, Mock> = {};
-      const self = () => qb as never;
-      qb.select = vi.fn().mockReturnValue(self());
-      qb.where = vi.fn().mockReturnValue(self());
-      qb.andWhere = vi.fn().mockReturnValue(self());
-      qb.getRawOne = vi.fn().mockResolvedValue({ total: '3600' });
-      qb.getRawMany = vi.fn().mockResolvedValue([]);
-      voiceDailyRepo.createQueryBuilder.mockReturnValue(qb);
+      // playtimeSec 미달 → getPlaytimeSec만 호출 (playtimeSec < targetPlaytimeSec이면 isMissionCompleted가 false 반환 즉시)
+      voiceDailyRepo.createQueryBuilder.mockReturnValue(makeQb({ total: '3600' }));
 
       await service.invalidateAndRefresh('guild-1');
 
@@ -1049,19 +937,12 @@ describe('MissionService', () => {
         memberName: '완료멤버',
       });
 
-      // IN_PROGRESS → enrichMissions 경로: fetchMemberDisplayName 사용
-      presenter.fetchMemberDisplayName.mockResolvedValue('활성멤버');
-      // COMPLETED → enrichHistoryMissions 경로: DB memberName 사용 (fetchMemberNickname 불필요)
+      // enrichMissionItems는 resolveMemberName을 사용하여 guildMemberService를 통해 조회한다
+      // guildMemberService.findByUserId가 null을 반환하면 mission.memberName을 그대로 사용
       const mockFetchNickname = vi.fn();
       (presenter as unknown as Record<string, unknown>)['fetchMemberNickname'] = mockFetchNickname;
 
-      const qb: Record<string, Mock> = {};
-      const self = () => qb as never;
-      qb.select = vi.fn().mockReturnValue(self());
-      qb.where = vi.fn().mockReturnValue(self());
-      qb.andWhere = vi.fn().mockReturnValue(self());
-      qb.getRawOne = vi.fn().mockResolvedValue({ total: '0' });
-      voiceDailyRepo.createQueryBuilder.mockReturnValue(qb);
+      voiceDailyRepo.createQueryBuilder.mockReturnValue(makeQb({ total: '0' }));
 
       const result = await service.enrichMissionItems('guild-1', [activeMission, completedMission]);
 
@@ -1069,7 +950,7 @@ describe('MissionService', () => {
       // 원래 배열 순서 보존
       expect(result[0].id).toBe(1);
       expect(result[1].id).toBe(2);
-      // COMPLETED는 DB memberName 사용 → fetchMemberNickname 미호출
+      // enrichMissionItems는 fetchMemberNickname을 사용하지 않는다
       expect(mockFetchNickname).not.toHaveBeenCalled();
     });
 
@@ -1091,17 +972,7 @@ describe('MissionService', () => {
       });
       const mission3 = makeMission({ id: 30, status: MissionStatus.FAILED, memberName: '실패' });
 
-      presenter.fetchMemberDisplayName.mockResolvedValue('진행중');
-      const mockFetchNickname = vi.fn();
-      (presenter as unknown as Record<string, unknown>)['fetchMemberNickname'] = mockFetchNickname;
-
-      const qb: Record<string, Mock> = {};
-      const self = () => qb as never;
-      qb.select = vi.fn().mockReturnValue(self());
-      qb.where = vi.fn().mockReturnValue(self());
-      qb.andWhere = vi.fn().mockReturnValue(self());
-      qb.getRawOne = vi.fn().mockResolvedValue({ total: '0' });
-      voiceDailyRepo.createQueryBuilder.mockReturnValue(qb);
+      voiceDailyRepo.createQueryBuilder.mockReturnValue(makeQb({ total: '0' }));
 
       const result = await service.enrichMissionItems('guild-1', [mission1, mission2, mission3]);
 
@@ -1120,7 +991,7 @@ describe('MissionService', () => {
       discordAction.fetchGuildMembers.mockResolvedValue([]);
     }
 
-    it('missionDisplayMode가 CANVAS이면 renderer.renderPage가 호출된다', async () => {
+    it('missionDisplayMode가 CANVAS이면 renderer.renderAll이 호출된다', async () => {
       configRepo.findByGuildId.mockResolvedValue(
         makeConfig({ missionDisplayMode: 'CANVAS', missionNotifyChannelId: 'ch-1' }),
       );
@@ -1128,7 +999,7 @@ describe('MissionService', () => {
 
       await service.refreshMissionEmbed('guild-1');
 
-      expect(renderer.renderPage).toHaveBeenCalled();
+      expect(renderer.renderAll).toHaveBeenCalled();
     });
 
     it('missionDisplayMode가 CANVAS이면 presenter.sendOrUpdateCanvasMission이 호출된다', async () => {
@@ -1165,7 +1036,7 @@ describe('MissionService', () => {
       expect(presenter.refreshMissionEmbed).not.toHaveBeenCalled();
     });
 
-    it('Canvas 캐시가 있으면 renderer.renderPage 없이 캐시 버퍼를 사용한다', async () => {
+    it('Canvas 캐시가 있으면 renderer.renderAll 없이 캐시 버퍼를 사용한다', async () => {
       configRepo.findByGuildId.mockResolvedValue(
         makeConfig({ missionDisplayMode: 'CANVAS', missionNotifyChannelId: 'ch-1' }),
       );
@@ -1174,7 +1045,7 @@ describe('MissionService', () => {
 
       await service.refreshMissionEmbed('guild-1');
 
-      expect(renderer.renderPage).not.toHaveBeenCalled();
+      expect(renderer.renderAll).not.toHaveBeenCalled();
       expect(presenter.sendOrUpdateCanvasMission).toHaveBeenCalled();
     });
   });

--- a/apps/api/src/newbie/application/moco/moco-rank.renderer.spec.ts
+++ b/apps/api/src/newbie/application/moco/moco-rank.renderer.spec.ts
@@ -239,8 +239,7 @@ describe('MocoRankRenderer', () => {
       const fillTextCalls = mockCtx.fillText.mock.calls.map((call) => call[0] as string);
       expect(
         fillTextCalls.some(
-          (text) =>
-            text.includes('15') && text.includes('2') && text.includes('8') && text.includes('5'),
+          (text) => text.includes('2') && text.includes('8') && text.includes('5'),
         ),
       ).toBe(true);
     });
@@ -345,8 +344,7 @@ describe('MocoRankRenderer', () => {
       const fillTextCalls = mockCtx.fillText.mock.calls.map((call) => call[0] as string);
       expect(
         fillTextCalls.some(
-          (text) =>
-            text.includes('20') && text.includes('3') && text.includes('10') && text.includes('15'),
+          (text) => text.includes('3') && text.includes('10') && text.includes('15'),
         ),
       ).toBe(true);
     });

--- a/apps/api/src/overview/application/overview.service.spec.ts
+++ b/apps/api/src/overview/application/overview.service.spec.ts
@@ -2,7 +2,8 @@ import type { Repository } from 'typeorm';
 import type { Mocked } from 'vitest';
 
 import type { VoiceDailyOrm } from '../../channel/voice/infrastructure/voice-daily.orm-entity';
-import type { DiscordRestService } from '../../discord-rest/discord-rest.service';
+import type { GuildMemberService } from '../../guild-member/application/guild-member.service';
+import type { GuildMemberOrmEntity } from '../../guild-member/infrastructure/guild-member.orm-entity';
 import type { InactiveMemberRecordOrm } from '../../inactive-member/infrastructure/inactive-member-record.orm-entity';
 import type { NewbieConfigRepository } from '../../newbie/infrastructure/newbie-config.repository';
 import type { NewbieMissionRepository } from '../../newbie/infrastructure/newbie-mission.repository';
@@ -33,7 +34,7 @@ const EXPECTED_ACTIVE_RATE = 67;
 // eslint-disable-next-line max-lines-per-function -- describe 블록은 구조상 불가피하게 길어진다
 describe('OverviewService', () => {
   let service: OverviewService;
-  let discordRest: Mocked<DiscordRestService>;
+  let guildMemberService: Mocked<GuildMemberService>;
   let newbieConfigRepo: Mocked<NewbieConfigRepository>;
   let newbieMissionRepo: Mocked<NewbieMissionRepository>;
   let redis: Mocked<RedisService>;
@@ -41,9 +42,9 @@ describe('OverviewService', () => {
   let inactiveRecordRepo: Mocked<Repository<InactiveMemberRecordOrm>>;
 
   beforeEach(() => {
-    discordRest = {
-      fetchGuild: vi.fn(),
-    } as unknown as Mocked<DiscordRestService>;
+    guildMemberService = {
+      findActiveMembersExcludingBots: vi.fn(),
+    } as unknown as Mocked<GuildMemberService>;
 
     newbieConfigRepo = {
       findByGuildId: vi.fn(),
@@ -66,7 +67,7 @@ describe('OverviewService', () => {
     } as unknown as Mocked<Repository<InactiveMemberRecordOrm>>;
 
     service = new OverviewService(
-      discordRest,
+      guildMemberService,
       newbieConfigRepo,
       newbieMissionRepo,
       redis,
@@ -78,10 +79,10 @@ describe('OverviewService', () => {
   // eslint-disable-next-line max-lines-per-function -- 다수의 it 케이스를 포함하는 describe 블록
   describe('getOverview', () => {
     beforeEach(() => {
-      // Discord REST: 1000명
-      discordRest.fetchGuild.mockResolvedValue({
-        approximate_member_count: 1000,
-      } as Awaited<ReturnType<typeof discordRest.fetchGuild>>);
+      // GuildMemberService: 1000명 반환
+      guildMemberService.findActiveMembersExcludingBots.mockResolvedValue(
+        Array.from({ length: 1000 }, () => ({}) as GuildMemberOrmEntity),
+      );
 
       // 오늘 voice totalSec
       const voiceTodayQb = makeQb({ totalSec: String(TWO_HOURS_IN_SECONDS) });
@@ -124,8 +125,8 @@ describe('OverviewService', () => {
       expect(result.currentVoiceUserCount).toBe(5);
     });
 
-    it('Discord fetchGuild이 null을 반환하면 totalMemberCount는 0이다', async () => {
-      discordRest.fetchGuild.mockResolvedValue(null);
+    it('활성 비봇 멤버가 없으면 totalMemberCount는 0이다', async () => {
+      guildMemberService.findActiveMembersExcludingBots.mockResolvedValue([]);
 
       const result = await service.getOverview('guild-1');
 
@@ -209,9 +210,7 @@ describe('OverviewService', () => {
         >;
       });
 
-      discordRest.fetchGuild.mockResolvedValue({ approximate_member_count: 0 } as Awaited<
-        ReturnType<typeof discordRest.fetchGuild>
-      >);
+      guildMemberService.findActiveMembersExcludingBots.mockResolvedValue([]);
       redis.get.mockResolvedValue(null);
       inactiveRecordRepo.createQueryBuilder.mockReturnValue(
         // as unknown 경유: makeQb 반환 객체가 SelectQueryBuilder 전체 인터페이스를 구현하지 않아 이중 단언이 필요하다

--- a/apps/api/src/voice-analytics/application/voice-ai-analysis-new-methods.spec.ts
+++ b/apps/api/src/voice-analytics/application/voice-ai-analysis-new-methods.spec.ts
@@ -136,14 +136,14 @@ describe('VoiceAiAnalysisService — 신규 메서드', () => {
       expect(result).toContain('주의 필요');
     });
 
-    it('maxOutputTokens: 512 옵션으로 LLM을 호출한다', async () => {
+    it('maxOutputTokens: 1024 옵션으로 LLM을 호출한다', async () => {
       llmProvider.generateText.mockResolvedValue('진단 결과');
 
       const data = makeVoiceActivityData();
       await service.generateHealthDiagnosis(60, data.totalStats, data.dailyTrends);
 
       expect(llmProvider.generateText).toHaveBeenCalledWith(expect.any(String), {
-        maxOutputTokens: 512,
+        maxOutputTokens: 1024,
       });
     });
   });

--- a/apps/api/src/voice-analytics/application/voice-ai-analysis.service.ts
+++ b/apps/api/src/voice-analytics/application/voice-ai-analysis.service.ts
@@ -193,7 +193,7 @@ Discord 서버 음성 채널 건강도 점수: ${score}점 (0~100점)
 `;
 
     try {
-      return await this.llmProvider.generateText(prompt, { maxOutputTokens: 512 });
+      return await this.llmProvider.generateText(prompt, { maxOutputTokens: 1024 });
     } catch (error) {
       this.logger.error('generateHealthDiagnosis failed', getErrorStack(error));
       const level =

--- a/apps/api/src/voice-analytics/application/voice-analytics-auto-channel-grouping.spec.ts
+++ b/apps/api/src/voice-analytics/application/voice-analytics-auto-channel-grouping.spec.ts
@@ -36,6 +36,8 @@ function makeChannelRecord(overrides: Partial<VoiceDailyOrm> = {}): VoiceDailyOr
     channelType: 'permanent',
     autoChannelConfigId: null,
     autoChannelConfigName: null,
+    autoChannelButtonId: null,
+    autoChannelButtonLabel: null,
     ...overrides,
   };
 }
@@ -61,6 +63,7 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
       voiceDailyRepo as never,
       { getGuildName: vi.fn().mockResolvedValue('테스트서버') } as never,
       nameEnricher as never,
+      { findByUserIds: vi.fn().mockResolvedValue(new Map()) } as never,
     );
   });
 
@@ -182,8 +185,8 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
   // ──────────────────────────────────────────────────────
   // groupAutoChannels=true (자동방 그룹핑)
   // ──────────────────────────────────────────────────────
-  describe('groupAutoChannels=true (자동방 configId 기준 그룹핑)', () => {
-    it('같은 autoChannelConfigId를 가진 자동방들이 하나의 항목으로 합산된다', async () => {
+  describe('groupAutoChannels=true (자동방 그룹핑)', () => {
+    it('buttonId가 없는 자동방들이 auto:config:{configId} 기준으로 합산된다', async () => {
       voiceDailyRepo.find.mockResolvedValue([
         makeChannelRecord({
           channelId: 'ch-a1',
@@ -192,6 +195,8 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
           autoChannelConfigId: 1,
           autoChannelConfigName: '게임방',
           channelType: 'auto_select',
+          autoChannelButtonId: null,
+          autoChannelButtonLabel: null,
         }),
         makeChannelRecord({
           channelId: 'ch-a2',
@@ -200,17 +205,19 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
           autoChannelConfigId: 1,
           autoChannelConfigName: '게임방',
           channelType: 'auto_select',
+          autoChannelButtonId: null,
+          autoChannelButtonLabel: null,
         }),
       ]);
 
       const result = await service.getChannelStats('guild-1', 7, { groupAutoChannels: true });
 
       expect(result).toHaveLength(1);
-      expect(result[0].channelId).toBe('auto:1');
+      expect(result[0].channelId).toBe('auto:config:1');
       expect(result[0].totalSec).toBe(3000);
     });
 
-    it('그룹핑된 항목의 channelId는 auto:{configId} 형식이다', async () => {
+    it('buttonId가 없는 경우 그룹핑된 항목의 channelId는 auto:config:{configId} 형식이다', async () => {
       voiceDailyRepo.find.mockResolvedValue([
         makeChannelRecord({
           channelId: 'ch-a1',
@@ -218,12 +225,112 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
           autoChannelConfigId: 99,
           autoChannelConfigName: '스터디방',
           channelType: 'auto_select',
+          autoChannelButtonId: null,
+          autoChannelButtonLabel: null,
         }),
       ]);
 
       const result = await service.getChannelStats('guild-1', 7, { groupAutoChannels: true });
 
-      expect(result[0].channelId).toBe('auto:99');
+      expect(result[0].channelId).toBe('auto:config:99');
+    });
+
+    it('buttonId가 있는 자동방들이 auto:button:{buttonId} 기준으로 합산된다', async () => {
+      voiceDailyRepo.find.mockResolvedValue([
+        makeChannelRecord({
+          channelId: 'ch-a1',
+          userId: 'user-1',
+          channelDurationSec: 1000,
+          autoChannelConfigId: 1,
+          autoChannelConfigName: '게임방',
+          channelType: 'auto_select',
+          autoChannelButtonId: 10,
+          autoChannelButtonLabel: '오버워치',
+        }),
+        makeChannelRecord({
+          channelId: 'ch-a2',
+          userId: 'user-2',
+          channelDurationSec: 2000,
+          autoChannelConfigId: 1,
+          autoChannelConfigName: '게임방',
+          channelType: 'auto_select',
+          autoChannelButtonId: 10,
+          autoChannelButtonLabel: '오버워치',
+        }),
+      ]);
+
+      const result = await service.getChannelStats('guild-1', 7, { groupAutoChannels: true });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].channelId).toBe('auto:button:10');
+      expect(result[0].totalSec).toBe(3000);
+    });
+
+    it('buttonId가 있는 경우 그룹핑된 항목의 channelId는 auto:button:{buttonId} 형식이다', async () => {
+      voiceDailyRepo.find.mockResolvedValue([
+        makeChannelRecord({
+          channelId: 'ch-a1',
+          channelDurationSec: 500,
+          autoChannelConfigId: 1,
+          autoChannelConfigName: '게임방',
+          channelType: 'auto_select',
+          autoChannelButtonId: 55,
+          autoChannelButtonLabel: '리그오브레전드',
+        }),
+      ]);
+
+      const result = await service.getChannelStats('guild-1', 7, { groupAutoChannels: true });
+
+      expect(result[0].channelId).toBe('auto:button:55');
+    });
+
+    it('같은 configId라도 buttonId가 다르면 별도 그룹으로 분리된다', async () => {
+      voiceDailyRepo.find.mockResolvedValue([
+        makeChannelRecord({
+          channelId: 'ch-a1',
+          channelDurationSec: 1000,
+          autoChannelConfigId: 1,
+          autoChannelConfigName: '게임방',
+          channelType: 'auto_select',
+          autoChannelButtonId: 10,
+          autoChannelButtonLabel: '오버워치',
+        }),
+        makeChannelRecord({
+          channelId: 'ch-a2',
+          channelDurationSec: 2000,
+          autoChannelConfigId: 1,
+          autoChannelConfigName: '게임방',
+          channelType: 'auto_select',
+          autoChannelButtonId: 20,
+          autoChannelButtonLabel: '리그오브레전드',
+        }),
+      ]);
+
+      const result = await service.getChannelStats('guild-1', 7, { groupAutoChannels: true });
+
+      expect(result).toHaveLength(2);
+      const channelIds = result.map((r) => r.channelId);
+      expect(channelIds).toContain('auto:button:10');
+      expect(channelIds).toContain('auto:button:20');
+    });
+
+    it('buttonId가 있는 그룹의 channelName은 autoChannelButtonLabel이다', async () => {
+      voiceDailyRepo.find.mockResolvedValue([
+        makeChannelRecord({
+          channelId: 'ch-a1',
+          channelName: '게임방-1호',
+          channelDurationSec: 500,
+          autoChannelConfigId: 1,
+          autoChannelConfigName: '게임방',
+          channelType: 'auto_select',
+          autoChannelButtonId: 10,
+          autoChannelButtonLabel: '오버워치',
+        }),
+      ]);
+
+      const result = await service.getChannelStats('guild-1', 7, { groupAutoChannels: true });
+
+      expect(result[0].channelName).toBe('오버워치');
     });
 
     it('그룹핑된 항목의 channelName은 autoChannelConfigName이다', async () => {
@@ -293,7 +400,7 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
       expect(result[0].uniqueUsers).toBe(3);
     });
 
-    it('서로 다른 configId는 별도 그룹으로 분리된다', async () => {
+    it('서로 다른 configId는 (buttonId 없을 때) 별도 그룹으로 분리된다', async () => {
       voiceDailyRepo.find.mockResolvedValue([
         makeChannelRecord({
           channelId: 'ch-a1',
@@ -301,6 +408,8 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
           autoChannelConfigId: 1,
           autoChannelConfigName: '게임방',
           channelType: 'auto_select',
+          autoChannelButtonId: null,
+          autoChannelButtonLabel: null,
         }),
         makeChannelRecord({
           channelId: 'ch-b1',
@@ -308,6 +417,8 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
           autoChannelConfigId: 2,
           autoChannelConfigName: '스터디방',
           channelType: 'auto_select',
+          autoChannelButtonId: null,
+          autoChannelButtonLabel: null,
         }),
       ]);
 
@@ -315,11 +426,11 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
 
       expect(result).toHaveLength(2);
       const channelIds = result.map((r) => r.channelId);
-      expect(channelIds).toContain('auto:1');
-      expect(channelIds).toContain('auto:2');
+      expect(channelIds).toContain('auto:config:1');
+      expect(channelIds).toContain('auto:config:2');
     });
 
-    it('상설 채널은 그룹핑되지 않고 그대로 유지된다', async () => {
+    it('상설 채널은 그룹핑되지 않고 그대로 유지된다 (buttonId 없는 자동방과 혼재)', async () => {
       voiceDailyRepo.find.mockResolvedValue([
         makeChannelRecord({
           channelId: 'ch-perm',
@@ -335,6 +446,8 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
           channelType: 'auto_select',
           autoChannelConfigId: 1,
           autoChannelConfigName: '게임방',
+          autoChannelButtonId: null,
+          autoChannelButtonLabel: null,
         }),
       ]);
 
@@ -343,10 +456,10 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
       expect(result).toHaveLength(2);
       const channelIds = result.map((r) => r.channelId);
       expect(channelIds).toContain('ch-perm');
-      expect(channelIds).toContain('auto:1');
+      expect(channelIds).toContain('auto:config:1');
     });
 
-    it('상설 채널과 그룹핑된 자동방이 totalSec 내림차순으로 함께 정렬된다', async () => {
+    it('상설 채널과 그룹핑된 자동방이 totalSec 내림차순으로 함께 정렬된다 (buttonId 없는 경우)', async () => {
       voiceDailyRepo.find.mockResolvedValue([
         makeChannelRecord({
           channelId: 'ch-perm',
@@ -361,6 +474,8 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
           channelType: 'auto_select',
           autoChannelConfigId: 1,
           autoChannelConfigName: '게임방',
+          autoChannelButtonId: null,
+          autoChannelButtonLabel: null,
         }),
         makeChannelRecord({
           channelId: 'ch-a2',
@@ -368,13 +483,15 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
           channelType: 'auto_select',
           autoChannelConfigId: 1,
           autoChannelConfigName: '게임방',
+          autoChannelButtonId: null,
+          autoChannelButtonLabel: null,
         }),
       ]);
 
-      // auto:1 = 2000+3000 = 5000, ch-perm = 500
+      // auto:config:1 = 2000+3000 = 5000, ch-perm = 500
       const result = await service.getChannelStats('guild-1', 7, { groupAutoChannels: true });
 
-      expect(result[0].channelId).toBe('auto:1');
+      expect(result[0].channelId).toBe('auto:config:1');
       expect(result[0].totalSec).toBe(5000);
       expect(result[1].channelId).toBe('ch-perm');
       expect(result[1].totalSec).toBe(500);
@@ -425,7 +542,7 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
       expect(result[0].autoChannelConfigName).toBe('스터디방');
     });
 
-    it('auto_instant 타입도 configId 기준으로 그룹핑된다', async () => {
+    it('auto_instant 타입은 buttonId가 null이므로 auto:config:{configId} 기준으로 그룹핑된다', async () => {
       voiceDailyRepo.find.mockResolvedValue([
         makeChannelRecord({
           channelId: 'ch-inst-1',
@@ -433,6 +550,8 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
           autoChannelConfigId: 5,
           autoChannelConfigName: '즉시방',
           channelType: 'auto_instant',
+          autoChannelButtonId: null,
+          autoChannelButtonLabel: null,
         }),
         makeChannelRecord({
           channelId: 'ch-inst-2',
@@ -440,13 +559,15 @@ describe('VoiceAnalyticsService — getChannelStats (auto-channel 그룹핑)', (
           autoChannelConfigId: 5,
           autoChannelConfigName: '즉시방',
           channelType: 'auto_instant',
+          autoChannelButtonId: null,
+          autoChannelButtonLabel: null,
         }),
       ]);
 
       const result = await service.getChannelStats('guild-1', 7, { groupAutoChannels: true });
 
       expect(result).toHaveLength(1);
-      expect(result[0].channelId).toBe('auto:5');
+      expect(result[0].channelId).toBe('auto:config:5');
       expect(result[0].totalSec).toBe(4000);
     });
 

--- a/apps/api/src/voice-analytics/application/voice-analytics-new-methods.spec.ts
+++ b/apps/api/src/voice-analytics/application/voice-analytics-new-methods.spec.ts
@@ -9,6 +9,9 @@
 vi.mock('../../discord-rest/discord-rest.service', () => ({ DiscordRestService: vi.fn() }));
 vi.mock('../../gateway/discord.gateway', () => ({ DiscordGateway: vi.fn() }));
 vi.mock('./voice-name-enricher.service', () => ({ VoiceNameEnricherService: vi.fn() }));
+vi.mock('../../guild-member/application/guild-member.service', () => ({
+  GuildMemberService: vi.fn(),
+}));
 
 import { type Mock } from 'vitest';
 
@@ -36,6 +39,8 @@ function makeGlobalRecord(overrides: Partial<VoiceDailyOrm> = {}): VoiceDailyOrm
     channelType: 'permanent',
     autoChannelConfigId: null,
     autoChannelConfigName: null,
+    autoChannelButtonId: null,
+    autoChannelButtonLabel: null,
     ...overrides,
   };
 }
@@ -61,6 +66,8 @@ function makeChannelRecord(overrides: Partial<VoiceDailyOrm> = {}): VoiceDailyOr
     channelType: 'permanent',
     autoChannelConfigId: null,
     autoChannelConfigName: null,
+    autoChannelButtonId: null,
+    autoChannelButtonLabel: null,
     ...overrides,
   };
 }
@@ -74,6 +81,7 @@ describe('VoiceAnalyticsService — 신규 메서드', () => {
     enrichChannelNames: Mock;
     enrichChannelStatsNames: Mock;
   };
+  let guildMemberService: { findByUserIds: Mock };
 
   beforeEach(() => {
     voiceDailyRepo = { find: vi.fn() };
@@ -83,11 +91,13 @@ describe('VoiceAnalyticsService — 신규 메서드', () => {
       enrichChannelNames: vi.fn().mockResolvedValue(undefined),
       enrichChannelStatsNames: vi.fn().mockResolvedValue(undefined),
     };
+    guildMemberService = { findByUserIds: vi.fn().mockResolvedValue(new Map()) };
 
     service = new VoiceAnalyticsService(
       voiceDailyRepo as never,
       discordGateway as never,
       nameEnricher as never,
+      guildMemberService as never,
     );
   });
 
@@ -162,6 +172,7 @@ describe('VoiceAnalyticsService — 신규 메서드', () => {
   // ──────────────────────────────────────────────────────
   describe('getLeaderboard', () => {
     it('totalVoiceTime 내림차순으로 정렬된다', async () => {
+      // getLeaderboard는 fetchRawRecords로 GLOBAL + 채널 레코드를 단일 쿼리로 가져온다
       const global1 = makeGlobalRecord({ userId: 'user-1', micOnSec: 100 });
       const global2 = makeGlobalRecord({ userId: 'user-2', userName: 'Bob', micOnSec: 200 });
       const channel1 = makeChannelRecord({ userId: 'user-1', channelDurationSec: 1000 });
@@ -171,9 +182,7 @@ describe('VoiceAnalyticsService — 신규 메서드', () => {
         userName: 'Bob',
       });
 
-      voiceDailyRepo.find
-        .mockResolvedValueOnce([global1, global2])
-        .mockResolvedValueOnce([channel1, channel2]);
+      voiceDailyRepo.find.mockResolvedValueOnce([global1, global2, channel1, channel2]);
 
       const result = await service.getLeaderboard('guild-1', { days: 7, page: 1, limit: 20 });
 
@@ -189,7 +198,7 @@ describe('VoiceAnalyticsService — 신규 메서드', () => {
         makeChannelRecord({ userId, userName: userId, channelDurationSec: (i + 1) * 1000 }),
       );
 
-      voiceDailyRepo.find.mockResolvedValueOnce(globals).mockResolvedValueOnce(channels);
+      voiceDailyRepo.find.mockResolvedValueOnce([...globals, ...channels]);
 
       const result = await service.getLeaderboard('guild-1', { days: 7, page: 1, limit: 20 });
 
@@ -205,7 +214,7 @@ describe('VoiceAnalyticsService — 신규 메서드', () => {
         makeChannelRecord({ userId: 'user-2', channelDurationSec: 3000, userName: 'user-2' }),
       ];
 
-      voiceDailyRepo.find.mockResolvedValueOnce(globals).mockResolvedValueOnce(channels);
+      voiceDailyRepo.find.mockResolvedValueOnce([...globals, ...channels]);
 
       const result = await service.getLeaderboard('guild-1', { days: 7, page: 2, limit: 1 });
 
@@ -224,9 +233,11 @@ describe('VoiceAnalyticsService — 신규 메서드', () => {
     });
 
     it('LeaderboardUser 필드(rank, userId, nickName, totalSec, micOnSec, activeDays)를 포함한다', async () => {
-      voiceDailyRepo.find
-        .mockResolvedValueOnce([makeGlobalRecord({ micOnSec: 1800 })])
-        .mockResolvedValueOnce([makeChannelRecord({ channelDurationSec: 3600 })]);
+      // GLOBAL 레코드(micOnSec)와 채널 레코드(channelDurationSec)를 함께 반환
+      voiceDailyRepo.find.mockResolvedValueOnce([
+        makeGlobalRecord({ micOnSec: 1800 }),
+        makeChannelRecord({ channelDurationSec: 3600 }),
+      ]);
 
       const result = await service.getLeaderboard('guild-1', { days: 7, page: 1, limit: 20 });
 
@@ -248,7 +259,7 @@ describe('VoiceAnalyticsService — 신규 메서드', () => {
         makeChannelRecord({ userId: 'user-2', channelDurationSec: 2000, userName: 'user-2' }),
       ];
 
-      voiceDailyRepo.find.mockResolvedValueOnce(globals).mockResolvedValueOnce(channels);
+      voiceDailyRepo.find.mockResolvedValueOnce([...globals, ...channels]);
 
       const result = await service.getLeaderboard('guild-1', { days: 7, page: 1, limit: 100 });
 
@@ -262,11 +273,11 @@ describe('VoiceAnalyticsService — 신규 메서드', () => {
   // ──────────────────────────────────────────────────────
   describe('getChannelStats', () => {
     it('채널별 ChannelStatItem을 반환한다', async () => {
-      voiceDailyRepo.find
-        .mockResolvedValueOnce([makeGlobalRecord()])
-        .mockResolvedValueOnce([
-          makeChannelRecord({ channelId: 'ch-1', channelName: '일반', channelDurationSec: 3600 }),
-        ]);
+      // getChannelStats는 fetchRawRecords로 단일 쿼리를 수행하며, GLOBAL 레코드는 내부에서 skip한다
+      voiceDailyRepo.find.mockResolvedValueOnce([
+        makeGlobalRecord(),
+        makeChannelRecord({ channelId: 'ch-1', channelName: '일반', channelDurationSec: 3600 }),
+      ]);
 
       const result = await service.getChannelStats('guild-1', 7);
 
@@ -286,15 +297,12 @@ describe('VoiceAnalyticsService — 신규 메서드', () => {
     });
 
     it('채널별 uniqueUsers가 정확히 집계된다', async () => {
-      voiceDailyRepo.find
-        .mockResolvedValueOnce([
-          makeGlobalRecord({ userId: 'user-1' }),
-          makeGlobalRecord({ userId: 'user-2', userName: 'Bob' }),
-        ])
-        .mockResolvedValueOnce([
-          makeChannelRecord({ userId: 'user-1', channelDurationSec: 1000 }),
-          makeChannelRecord({ userId: 'user-2', channelDurationSec: 2000, userName: 'Bob' }),
-        ]);
+      voiceDailyRepo.find.mockResolvedValueOnce([
+        makeGlobalRecord({ userId: 'user-1' }),
+        makeGlobalRecord({ userId: 'user-2', userName: 'Bob' }),
+        makeChannelRecord({ userId: 'user-1', channelDurationSec: 1000 }),
+        makeChannelRecord({ userId: 'user-2', channelDurationSec: 2000, userName: 'Bob' }),
+      ]);
 
       const result = await service.getChannelStats('guild-1', 7);
 
@@ -302,12 +310,11 @@ describe('VoiceAnalyticsService — 신규 메서드', () => {
     });
 
     it('여러 채널이 있으면 totalSec 내림차순으로 정렬된다', async () => {
-      voiceDailyRepo.find
-        .mockResolvedValueOnce([makeGlobalRecord()])
-        .mockResolvedValueOnce([
-          makeChannelRecord({ channelId: 'ch-1', channelName: '일반', channelDurationSec: 1000 }),
-          makeChannelRecord({ channelId: 'ch-2', channelName: '게임', channelDurationSec: 5000 }),
-        ]);
+      voiceDailyRepo.find.mockResolvedValueOnce([
+        makeGlobalRecord(),
+        makeChannelRecord({ channelId: 'ch-1', channelName: '일반', channelDurationSec: 1000 }),
+        makeChannelRecord({ channelId: 'ch-2', channelName: '게임', channelDurationSec: 5000 }),
+      ]);
 
       const result = await service.getChannelStats('guild-1', 7);
 
@@ -316,9 +323,10 @@ describe('VoiceAnalyticsService — 신규 메서드', () => {
     });
 
     it('ChannelStatItem에 categoryId=null, categoryName=null이 포함된다', async () => {
-      voiceDailyRepo.find
-        .mockResolvedValueOnce([makeGlobalRecord()])
-        .mockResolvedValueOnce([makeChannelRecord({ channelDurationSec: 3600 })]);
+      voiceDailyRepo.find.mockResolvedValueOnce([
+        makeGlobalRecord(),
+        makeChannelRecord({ channelDurationSec: 3600 }),
+      ]);
 
       const result = await service.getChannelStats('guild-1', 7);
 
@@ -441,9 +449,9 @@ describe('VoiceAnalyticsService — 신규 메서드', () => {
 
       const result = await service.getHealthScore('guild-1', 7);
 
-      // score = min(100, 5*10 + (36000/3600/7)*5) = min(100, 50 + 7.14) = 57
-      // prevScore = min(100, 0*10 + 0) = 0
-      // delta = 57 > 0
+      // 현재 기간: 활성 유저 5명, 음성 시간 36000초, 마이크 18000초 → score > 0
+      // 이전 기간: 모두 0 → prevScore = 0
+      // delta > 0
       expect(result.delta).toBeGreaterThan(0);
 
       collectSpy.mockRestore();

--- a/apps/api/src/voice-analytics/application/voice-analytics.service.spec.ts
+++ b/apps/api/src/voice-analytics/application/voice-analytics.service.spec.ts
@@ -24,6 +24,8 @@ function makeGlobalRecord(overrides: Partial<VoiceDailyOrm> = {}): VoiceDailyOrm
     channelType: 'permanent',
     autoChannelConfigId: null,
     autoChannelConfigName: null,
+    autoChannelButtonId: null,
+    autoChannelButtonLabel: null,
     ...overrides,
   };
 }
@@ -49,6 +51,8 @@ function makeChannelRecord(overrides: Partial<VoiceDailyOrm> = {}): VoiceDailyOr
     channelType: 'permanent',
     autoChannelConfigId: null,
     autoChannelConfigName: null,
+    autoChannelButtonId: null,
+    autoChannelButtonLabel: null,
     ...overrides,
   };
 }
@@ -76,6 +80,7 @@ describe('VoiceAnalyticsService', () => {
       voiceDailyRepo as never,
       discordGateway as never,
       nameEnricher as never,
+      { findByUserIds: vi.fn().mockResolvedValue(new Map()) } as never,
     );
   });
 

--- a/apps/api/src/voice-analytics/application/voice-analytics.service.ts
+++ b/apps/api/src/voice-analytics/application/voice-analytics.service.ts
@@ -7,6 +7,7 @@ import { Between, Not, Repository } from 'typeorm';
 import { VoiceDailyOrm } from '../../channel/voice/infrastructure/voice-daily.orm-entity';
 import { getErrorStack } from '../../common/util/error.util';
 import { DiscordGateway } from '../../gateway/discord.gateway';
+import { GuildMemberService } from '../../guild-member/application/guild-member.service';
 import { UserAggregateData, VoiceNameEnricherService } from './voice-name-enricher.service';
 
 export type { VoiceActivityData } from '@onyu/shared';
@@ -36,6 +37,8 @@ interface ChannelStatAggregate {
   channelType: ChannelType;
   autoChannelConfigId: number | null;
   autoChannelConfigName: string | null;
+  autoChannelButtonId: number | null;
+  autoChannelButtonLabel: string | null;
 }
 
 interface DailyAggregate {
@@ -54,6 +57,7 @@ export class VoiceAnalyticsService {
     private voiceDailyRepo: Repository<VoiceDailyOrm>,
     private discordGateway: DiscordGateway,
     private nameEnricher: VoiceNameEnricherService,
+    private guildMemberService: GuildMemberService,
   ) {}
 
   async collectVoiceActivityData(
@@ -376,8 +380,8 @@ export class VoiceAnalyticsService {
       this.collectVoiceActivityData(guildId, prevRange.start, prevRange.end),
     ]);
 
-    const score = this.calculateHealthScore(currentData.totalStats, days);
-    const prevScore = this.calculateHealthScore(prevData.totalStats, days);
+    const score = this.calculateHealthScore(currentData.totalStats, currentData.dailyTrends, days);
+    const prevScore = this.calculateHealthScore(prevData.totalStats, prevData.dailyTrends, days);
     const delta = score - prevScore;
 
     return {
@@ -459,6 +463,15 @@ export class VoiceAnalyticsService {
       user.rank = offset + index + 1;
     });
 
+    const pagedUserIds = paged.map((u) => u.userId);
+    const memberMap = await this.guildMemberService.findByUserIds(guildId, pagedUserIds);
+    for (const user of paged) {
+      const member = memberMap.get(user.userId);
+      if (member) {
+        user.avatarUrl = member.avatarUrl ?? null;
+      }
+    }
+
     return { users: paged, total };
   }
 
@@ -484,6 +497,8 @@ export class VoiceAnalyticsService {
         channelType: r.channelType ?? 'permanent',
         autoChannelConfigId: r.autoChannelConfigId ?? null,
         autoChannelConfigName: r.autoChannelConfigName ?? null,
+        autoChannelButtonId: r.autoChannelButtonId ?? null,
+        autoChannelButtonLabel: r.autoChannelButtonLabel ?? null,
       };
       existing.totalSec += r.channelDurationSec;
       existing.uniqueUsers.add(r.userId);
@@ -493,6 +508,8 @@ export class VoiceAnalyticsService {
       if (r.channelType && r.channelType !== 'permanent') existing.channelType = r.channelType;
       if (r.autoChannelConfigId) existing.autoChannelConfigId = r.autoChannelConfigId;
       if (r.autoChannelConfigName) existing.autoChannelConfigName = r.autoChannelConfigName;
+      if (r.autoChannelButtonId) existing.autoChannelButtonId = r.autoChannelButtonId;
+      if (r.autoChannelButtonLabel) existing.autoChannelButtonLabel = r.autoChannelButtonLabel;
       chMap.set(r.channelId, existing);
     }
 
@@ -511,6 +528,8 @@ export class VoiceAnalyticsService {
         channelType: ch.channelType,
         autoChannelConfigId: ch.autoChannelConfigId,
         autoChannelConfigName: ch.autoChannelConfigName,
+        autoChannelButtonId: ch.autoChannelButtonId,
+        autoChannelButtonLabel: ch.autoChannelButtonLabel,
       }))
       .sort((a, b) => b.totalSec - a.totalSec);
   }
@@ -532,6 +551,8 @@ export class VoiceAnalyticsService {
         channelType: ch.channelType,
         autoChannelConfigId: ch.autoChannelConfigId,
         autoChannelConfigName: ch.autoChannelConfigName,
+        autoChannelButtonId: ch.autoChannelButtonId,
+        autoChannelButtonLabel: ch.autoChannelButtonLabel,
         totalSec: ch.totalSec,
         uniqueUsers: ch.uniqueUsers.size,
       }))
@@ -551,8 +572,11 @@ export class VoiceAnalyticsService {
         continue;
       }
 
-      // 자동방: configId 기준 그룹핑
-      const groupKey = `auto:${ch.autoChannelConfigId}`;
+      // 자동방: buttonId가 있으면 button 기준, 없으면 configId 기준 그룹핑
+      const groupKey =
+        ch.autoChannelButtonId != null
+          ? `auto:button:${ch.autoChannelButtonId}`
+          : `auto:config:${ch.autoChannelConfigId}`;
       const existing = resultMap.get(groupKey);
 
       if (existing) {
@@ -560,14 +584,17 @@ export class VoiceAnalyticsService {
         for (const userId of ch.uniqueUsers) {
           existing.uniqueUsers.add(userId);
         }
+        if (ch.autoChannelButtonLabel) existing.autoChannelButtonLabel = ch.autoChannelButtonLabel;
       } else {
         resultMap.set(groupKey, {
-          channelName: ch.autoChannelConfigName ?? ch.channelName,
+          channelName: ch.autoChannelButtonLabel ?? ch.autoChannelConfigName ?? ch.channelName,
           categoryId: ch.categoryId,
           categoryName: ch.categoryName,
           channelType: ch.channelType,
           autoChannelConfigId: ch.autoChannelConfigId,
           autoChannelConfigName: ch.autoChannelConfigName,
+          autoChannelButtonId: ch.autoChannelButtonId,
+          autoChannelButtonLabel: ch.autoChannelButtonLabel,
           totalSec: ch.totalSec,
           uniqueUsers: new Set(ch.uniqueUsers),
         });
@@ -577,10 +604,38 @@ export class VoiceAnalyticsService {
     return resultMap;
   }
 
-  private calculateHealthScore(totalStats: VoiceActivityData['totalStats'], days: number): number {
-    const activeUserScore = totalStats.avgDailyActiveUsers * 10;
-    const voiceTimeScore = (totalStats.totalVoiceTime / 3600 / days) * 5;
-    return Math.min(100, Math.round(activeUserScore + voiceTimeScore));
+  /**
+   * 서버 음성 활동 건강도를 0~100으로 산출한다.
+   *
+   * 각 지표를 로그 커브(value / (value + midpoint))로 0~100 정규화한 뒤 가중 합산.
+   * - 일평균 활성 유저 (40%) midpoint=10
+   * - 일평균 총 음성 시간 (30%) midpoint=5h
+   * - 마이크 사용률 (20%) midpoint=30%
+   * - 활동일 비율 (10%) midpoint=50%
+   */
+  private calculateHealthScore(
+    totalStats: VoiceActivityData['totalStats'],
+    dailyTrends: VoiceActivityData['dailyTrends'],
+    days: number,
+  ): number {
+    const normalize = (value: number, midpoint: number) =>
+      midpoint === 0 ? 0 : (100 * value) / (value + midpoint);
+
+    const avgDailyUsers = totalStats.avgDailyActiveUsers;
+    const avgDailyHours = totalStats.totalVoiceTime / 3600 / days;
+    const micUsageRate =
+      totalStats.totalVoiceTime > 0
+        ? (totalStats.totalMicOnTime / totalStats.totalVoiceTime) * 100
+        : 0;
+    const activeDayRatio = days > 0 ? (dailyTrends.length / days) * 100 : 0;
+
+    const score =
+      normalize(avgDailyUsers, 10) * 0.4 +
+      normalize(avgDailyHours, 5) * 0.3 +
+      normalize(micUsageRate, 30) * 0.2 +
+      normalize(activeDayRatio, 50) * 0.1;
+
+    return Math.min(100, Math.round(score));
   }
 
   static getDateRange(days: number): { start: string; end: string } {

--- a/apps/api/src/voice-analytics/presentation/diagnosis.controller.spec.ts
+++ b/apps/api/src/voice-analytics/presentation/diagnosis.controller.spec.ts
@@ -140,8 +140,9 @@ describe('DiagnosisController', () => {
     };
 
     it('정상 응답: score, prevScore, delta, diagnosis를 반환한다', async () => {
+      // getHealthScore 엔드포인트는 diagnosis: ''(빈 문자열)로 반환한다.
+      // generateHealthDiagnosis 호출은 getHealthDiagnosis 엔드포인트에서 수행된다.
       analyticsService.getHealthScore.mockResolvedValue(mockHealthScoreData);
-      aiAnalysisService.generateHealthDiagnosis.mockResolvedValue('서버 상태 양호');
 
       const query = new DiagnosisQueryDto();
       query.days = 7;
@@ -151,23 +152,19 @@ describe('DiagnosisController', () => {
       expect(result.score).toBe(75);
       expect(result.prevScore).toBe(60);
       expect(result.delta).toBe(15);
-      expect(result.diagnosis).toBe('서버 상태 양호');
+      expect(result.diagnosis).toBe('');
     });
 
-    it('getHealthScore 후 generateHealthDiagnosis를 호출한다', async () => {
+    it('getHealthScore는 generateHealthDiagnosis를 호출하지 않는다', async () => {
+      // AI 진단 호출은 별도 엔드포인트(getHealthDiagnosis)에서 수행된다
       analyticsService.getHealthScore.mockResolvedValue(mockHealthScoreData);
-      aiAnalysisService.generateHealthDiagnosis.mockResolvedValue('진단 결과');
 
       const query = new DiagnosisQueryDto();
       query.days = 7;
 
       await controller.getHealthScore(GUILD_ID, query);
 
-      expect(aiAnalysisService.generateHealthDiagnosis).toHaveBeenCalledWith(
-        75,
-        mockHealthScoreData.totalStats,
-        mockHealthScoreData.dailyTrends,
-      );
+      expect(aiAnalysisService.generateHealthDiagnosis).not.toHaveBeenCalled();
     });
 
     it('Redis 캐시 히트 시 서비스를 호출하지 않는다', async () => {
@@ -186,7 +183,6 @@ describe('DiagnosisController', () => {
 
     it('캐시 키에 guildId와 days가 포함된다', async () => {
       analyticsService.getHealthScore.mockResolvedValue(mockHealthScoreData);
-      aiAnalysisService.generateHealthDiagnosis.mockResolvedValue('진단');
 
       const query = new DiagnosisQueryDto();
       query.days = 14;
@@ -300,13 +296,17 @@ describe('DiagnosisController', () => {
       ];
       analyticsService.getChannelStats.mockResolvedValue(channels);
 
+      // ChannelStatsQueryDto는 DiagnosisQueryDto를 상속하며 groupAutoChannels 필드를 추가로 갖는다
       const query = new DiagnosisQueryDto();
       query.days = 7;
 
-      const result = await controller.getChannelStats(GUILD_ID, query);
+      const result = await controller.getChannelStats(GUILD_ID, query as never);
 
       expect(result.channels).toEqual(channels);
-      expect(analyticsService.getChannelStats).toHaveBeenCalledWith(GUILD_ID, 7);
+      // 컨트롤러는 groupAutoChannels 옵션을 포함하여 서비스를 호출한다
+      expect(analyticsService.getChannelStats).toHaveBeenCalledWith(GUILD_ID, 7, {
+        groupAutoChannels: false,
+      });
     });
 
     it('Redis 캐시 히트 시 서비스를 호출하지 않는다', async () => {
@@ -316,7 +316,7 @@ describe('DiagnosisController', () => {
       const query = new DiagnosisQueryDto();
       query.days = 7;
 
-      const result = await controller.getChannelStats(GUILD_ID, query);
+      const result = await controller.getChannelStats(GUILD_ID, query as never);
 
       expect(result).toEqual(cached);
       expect(analyticsService.getChannelStats).not.toHaveBeenCalled();
@@ -360,22 +360,25 @@ describe('DiagnosisController', () => {
       expect(result.suggestions).toEqual(['이벤트를 열어보세요']);
     });
 
-    it('Redis 캐시 히트 시 서비스를 호출하지 않는다', async () => {
-      const cached = {
-        insights: '캐시된 인사이트',
+    it('POST generateAiInsight는 항상 LLM을 호출한다 (캐시 무시)', async () => {
+      // POST 엔드포인트는 사용자의 "분석 새로고침" 요청이므로 캐시를 체크하지 않고 항상 LLM을 재호출한다
+      analyticsService.collectVoiceActivityData.mockResolvedValue(mockActivityData);
+      const insight = {
+        insights: '새로 생성된 인사이트',
         suggestions: [],
         generatedAt: new Date().toISOString(),
       };
-      redis.get.mockResolvedValue(cached);
+      aiAnalysisService.generateAiInsight.mockResolvedValue(insight);
 
       const query = new DiagnosisQueryDto();
       query.days = 7;
 
       const result = await controller.generateAiInsight(GUILD_ID, query);
 
-      expect(result).toEqual(cached);
-      expect(analyticsService.collectVoiceActivityData).not.toHaveBeenCalled();
-      expect(aiAnalysisService.generateAiInsight).not.toHaveBeenCalled();
+      // 캐시 여부와 상관없이 항상 서비스를 호출한다
+      expect(analyticsService.collectVoiceActivityData).toHaveBeenCalled();
+      expect(aiAnalysisService.generateAiInsight).toHaveBeenCalledWith(mockActivityData);
+      expect(result.insights).toBe('새로 생성된 인사이트');
     });
 
     it('캐시 미스 시 collectVoiceActivityData 후 generateAiInsight를 호출한다', async () => {

--- a/apps/web/app/dashboard/guild/[guildId]/voice/components/ChannelBarChart.tsx
+++ b/apps/web/app/dashboard/guild/[guildId]/voice/components/ChannelBarChart.tsx
@@ -87,7 +87,7 @@ export default function ChannelBarChart({
     }));
 
   const autoGroupChartData = autoGroupStats.slice(0, 10).map((d) => ({
-    name: d.autoChannelConfigName,
+    name: d.autoChannelButtonLabel ?? d.autoChannelConfigName,
     durationMin: Math.round(d.totalDurationSec / 60),
     micOnMin: 0,
     micOffMin: 0,
@@ -120,11 +120,15 @@ export default function ChannelBarChart({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="all">{t('voice.channelChart.filterAll')}</SelectItem>
-                  <SelectItem value="permanent">
+                  <SelectItem value="all" label={t('voice.channelChart.filterAll')}>
+                    {t('voice.channelChart.filterAll')}
+                  </SelectItem>
+                  <SelectItem value="permanent" label={t('voice.channelChart.filterPermanent')}>
                     {t('voice.channelChart.filterPermanent')}
                   </SelectItem>
-                  <SelectItem value="auto">{t('voice.channelChart.filterAuto')}</SelectItem>
+                  <SelectItem value="auto" label={t('voice.channelChart.filterAuto')}>
+                    {t('voice.channelChart.filterAuto')}
+                  </SelectItem>
                 </SelectContent>
               </Select>
             )}

--- a/apps/web/app/lib/__tests__/voice-dashboard-api.test.ts
+++ b/apps/web/app/lib/__tests__/voice-dashboard-api.test.ts
@@ -5,10 +5,12 @@
  * 집계 함수들의 순수 로직을 검증한다.
  *
  * 검증 대상:
- * - computeAutoChannelGroupStats(): config 단위 그룹핑, instanceCount 정확성
+ * - computeAutoChannelGroupStats(): button 단위 그룹핑, instanceCount 정확성
  * - computeChannelStats(records, 'auto_grouped'): 자동방 합산, 상설 채널 유지
+ *   - buttonId가 있으면 'auto:btn:{buttonId}' 키 사용
+ *   - buttonId가 없으면 'auto:cfg:{configId}' 폴백
  * - computeChannelStats(records, 'individual'): 기존 동작 보존
- * - computeSummary(): uniqueChannels가 자동방 config 단위로 카운트되는지
+ * - computeSummary(): uniqueChannels가 자동방 button 단위로 카운트되는지
  * - filterRecordsByChannelType(): 각 필터 옵션(all/permanent/auto) 정상 동작, GLOBAL 레코드 항상 유지
  * - 하위 호환성: channelType/autoChannelConfigId undefined 레코드에서 정상 동작
  */
@@ -77,7 +79,7 @@ const PERMANENT_CH2: VoiceDailyRecord = makeRecord({
   autoChannelConfigName: null,
 });
 
-/** 자동방 레코드 - config 1 */
+/** 자동방 레코드 - config 1, buttonId 없음 (auto:cfg:1 폴백) */
 const AUTO_CONFIG1_INSTANCE1: VoiceDailyRecord = makeRecord({
   channelId: 'auto-ch-101',
   channelName: '방 #1',
@@ -85,6 +87,8 @@ const AUTO_CONFIG1_INSTANCE1: VoiceDailyRecord = makeRecord({
   channelType: 'auto_select',
   autoChannelConfigId: 1,
   autoChannelConfigName: '자유 채팅방',
+  autoChannelButtonId: null,
+  autoChannelButtonLabel: null,
 });
 
 const AUTO_CONFIG1_INSTANCE2: VoiceDailyRecord = makeRecord({
@@ -94,6 +98,8 @@ const AUTO_CONFIG1_INSTANCE2: VoiceDailyRecord = makeRecord({
   channelType: 'auto_select',
   autoChannelConfigId: 1,
   autoChannelConfigName: '자유 채팅방',
+  autoChannelButtonId: null,
+  autoChannelButtonLabel: null,
 });
 
 const AUTO_CONFIG1_INSTANCE3: VoiceDailyRecord = makeRecord({
@@ -103,9 +109,11 @@ const AUTO_CONFIG1_INSTANCE3: VoiceDailyRecord = makeRecord({
   channelType: 'auto_select',
   autoChannelConfigId: 1,
   autoChannelConfigName: '자유 채팅방',
+  autoChannelButtonId: null,
+  autoChannelButtonLabel: null,
 });
 
-/** 자동방 레코드 - config 2 */
+/** 자동방 레코드 - config 2, buttonId 없음 (auto:cfg:2 폴백) */
 const AUTO_CONFIG2_INSTANCE1: VoiceDailyRecord = makeRecord({
   channelId: 'auto-ch-201',
   channelName: '게임방 #1',
@@ -113,6 +121,8 @@ const AUTO_CONFIG2_INSTANCE1: VoiceDailyRecord = makeRecord({
   channelType: 'auto_instant',
   autoChannelConfigId: 2,
   autoChannelConfigName: '게임 채널',
+  autoChannelButtonId: null,
+  autoChannelButtonLabel: null,
 });
 
 /** 다중 유저, 다중 날짜 픽스처 */
@@ -322,31 +332,31 @@ describe('computeChannelStats - auto_grouped 모드', () => {
     expect(result.every((r) => r.channelId !== 'GLOBAL')).toBe(true);
   });
 
-  it('동일 configId의 자동방 레코드를 하나의 항목으로 합산한다', () => {
+  it('동일 configId의 자동방 레코드를 하나의 항목으로 합산한다 (buttonId 없으면 auto:cfg:{configId})', () => {
     const records = [AUTO_CONFIG1_INSTANCE1, AUTO_CONFIG1_INSTANCE2];
 
     const result = computeChannelStats(records, 'auto_grouped');
 
-    const autoGroup = result.find((r) => r.channelId === 'auto:1');
+    const autoGroup = result.find((r) => r.channelId === 'auto:cfg:1');
     expect(autoGroup).toBeDefined();
     expect(autoGroup?.totalDurationSec).toBe(1800); // 600 + 1200
   });
 
-  it('합산된 자동방 항목의 channelId가 "auto:{configId}" 형식이다', () => {
+  it('합산된 자동방 항목의 channelId가 "auto:cfg:{configId}" 형식이다 (buttonId 없는 경우)', () => {
     const records = [AUTO_CONFIG1_INSTANCE1, AUTO_CONFIG2_INSTANCE1];
 
     const result = computeChannelStats(records, 'auto_grouped');
 
-    expect(result.some((r) => r.channelId === 'auto:1')).toBe(true);
-    expect(result.some((r) => r.channelId === 'auto:2')).toBe(true);
+    expect(result.some((r) => r.channelId === 'auto:cfg:1')).toBe(true);
+    expect(result.some((r) => r.channelId === 'auto:cfg:2')).toBe(true);
   });
 
-  it('합산된 자동방 항목의 channelName이 autoChannelConfigName을 사용한다', () => {
+  it('합산된 자동방 항목의 channelName이 autoChannelConfigName을 사용한다 (buttonLabel 없는 경우)', () => {
     const records = [AUTO_CONFIG1_INSTANCE1];
 
     const result = computeChannelStats(records, 'auto_grouped');
 
-    const autoGroup = result.find((r) => r.channelId === 'auto:1');
+    const autoGroup = result.find((r) => r.channelId === 'auto:cfg:1');
     expect(autoGroup?.channelName).toBe('자유 채팅방');
   });
 
@@ -365,7 +375,7 @@ describe('computeChannelStats - auto_grouped 모드', () => {
     const result = computeChannelStats(records, 'auto_grouped');
 
     const permanent = result.find((r) => r.channelId === 'ch-001');
-    const autoGroup = result.find((r) => r.channelId === 'auto:1');
+    const autoGroup = result.find((r) => r.channelId === 'auto:cfg:1');
 
     expect(permanent?.totalDurationSec).toBe(1800);
     expect(autoGroup?.totalDurationSec).toBe(1800); // 600 + 1200
@@ -379,6 +389,8 @@ describe('computeChannelStats - auto_grouped 모드', () => {
       channelType: 'auto_select',
       autoChannelConfigId: 1,
       autoChannelConfigName: '자유방',
+      autoChannelButtonId: null,
+      autoChannelButtonLabel: null,
       micOnSec: 100,
       micOffSec: 50,
       aloneSec: 20,
@@ -390,6 +402,8 @@ describe('computeChannelStats - auto_grouped 모드', () => {
       channelType: 'auto_select',
       autoChannelConfigId: 1,
       autoChannelConfigName: '자유방',
+      autoChannelButtonId: null,
+      autoChannelButtonLabel: null,
       micOnSec: 200,
       micOffSec: 80,
       aloneSec: 30,
@@ -397,7 +411,7 @@ describe('computeChannelStats - auto_grouped 모드', () => {
 
     const result = computeChannelStats([r1, r2], 'auto_grouped');
 
-    const autoGroup = result.find((r) => r.channelId === 'auto:1');
+    const autoGroup = result.find((r) => r.channelId === 'auto:cfg:1');
     expect(autoGroup?.micOnSec).toBe(300);
     expect(autoGroup?.micOffSec).toBe(130);
     expect(autoGroup?.aloneSec).toBe(50);
@@ -807,7 +821,8 @@ describe('경계값 및 통합 시나리오', () => {
     const channelStats = computeChannelStats(records, 'auto_grouped');
 
     expect(autoStats[0].instanceCount).toBe(1);
-    expect(channelStats[0].channelId).toBe('auto:1');
+    // buttonId가 null이므로 configId 폴백: 'auto:cfg:{configId}'
+    expect(channelStats[0].channelId).toBe('auto:cfg:1');
   });
 
   it('같은 유저가 다수 채널에 접속한 경우 computeSummary의 uniqueChannels가 정확하다', () => {
@@ -834,7 +849,267 @@ describe('경계값 및 통합 시나리오', () => {
     const groupStats = computeAutoChannelGroupStats(records);
     const channelStats = computeChannelStats(records, 'auto_grouped');
 
-    const autoGroup = channelStats.find((r) => r.channelId === 'auto:1');
+    // buttonId가 null이므로 'auto:cfg:1' 키 사용
+    const autoGroup = channelStats.find((r) => r.channelId === 'auto:cfg:1');
     expect(groupStats[0].totalDurationSec).toBe(autoGroup?.totalDurationSec);
+  });
+});
+
+// ─── 버튼 단위 그룹핑 신규 테스트 ────────────────────────────────────────────────
+
+describe('button 단위 그룹핑 (buttonId 기준)', () => {
+  /** config 1 안의 버튼 A (buttonId: 10) */
+  const CONFIG1_BTN_A_INST1: VoiceDailyRecord = makeRecord({
+    channelId: 'auto-ch-101',
+    channelName: '방 #1',
+    channelDurationSec: 600,
+    channelType: 'auto_select',
+    autoChannelConfigId: 1,
+    autoChannelConfigName: '자유 채팅방',
+    autoChannelButtonId: 10,
+    autoChannelButtonLabel: '게임하기',
+  });
+
+  const CONFIG1_BTN_A_INST2: VoiceDailyRecord = makeRecord({
+    channelId: 'auto-ch-102',
+    channelName: '방 #2',
+    channelDurationSec: 900,
+    channelType: 'auto_select',
+    autoChannelConfigId: 1,
+    autoChannelConfigName: '자유 채팅방',
+    autoChannelButtonId: 10,
+    autoChannelButtonLabel: '게임하기',
+  });
+
+  /** config 1 안의 버튼 B (buttonId: 20) */
+  const CONFIG1_BTN_B_INST1: VoiceDailyRecord = makeRecord({
+    channelId: 'auto-ch-201',
+    channelName: '방 #1',
+    channelDurationSec: 1200,
+    channelType: 'auto_select',
+    autoChannelConfigId: 1,
+    autoChannelConfigName: '자유 채팅방',
+    autoChannelButtonId: 20,
+    autoChannelButtonLabel: '공부하기',
+  });
+
+  describe('computeChannelStats - auto_grouped', () => {
+    it('buttonId가 있으면 "auto:btn:{buttonId}" 키로 그룹핑된다', () => {
+      const result = computeChannelStats([CONFIG1_BTN_A_INST1], 'auto_grouped');
+
+      expect(result[0].channelId).toBe('auto:btn:10');
+    });
+
+    it('동일 buttonId를 가진 인스턴스들이 하나의 항목으로 합산된다', () => {
+      const result = computeChannelStats(
+        [CONFIG1_BTN_A_INST1, CONFIG1_BTN_A_INST2],
+        'auto_grouped',
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].channelId).toBe('auto:btn:10');
+      expect(result[0].totalDurationSec).toBe(1500); // 600 + 900
+    });
+
+    it('동일 configId 내 서로 다른 buttonId는 별도 그룹으로 분리된다', () => {
+      const result = computeChannelStats(
+        [CONFIG1_BTN_A_INST1, CONFIG1_BTN_A_INST2, CONFIG1_BTN_B_INST1],
+        'auto_grouped',
+      );
+
+      // 버튼 A와 버튼 B가 같은 configId(1)임에도 별도 그룹
+      expect(result).toHaveLength(2);
+      expect(result.some((r) => r.channelId === 'auto:btn:10')).toBe(true);
+      expect(result.some((r) => r.channelId === 'auto:btn:20')).toBe(true);
+    });
+
+    it('channelName으로 buttonLabel이 사용된다', () => {
+      const result = computeChannelStats([CONFIG1_BTN_A_INST1], 'auto_grouped');
+
+      expect(result[0].channelName).toBe('게임하기');
+    });
+
+    it('buttonLabel이 null이면 configName을 channelName으로 사용한다', () => {
+      const recordWithNullLabel = makeRecord({
+        channelId: 'auto-ch-301',
+        channelName: '방 #1',
+        channelDurationSec: 500,
+        channelType: 'auto_select',
+        autoChannelConfigId: 5,
+        autoChannelConfigName: '음악 방',
+        autoChannelButtonId: 30,
+        autoChannelButtonLabel: null,
+      });
+
+      const result = computeChannelStats([recordWithNullLabel], 'auto_grouped');
+
+      expect(result[0].channelId).toBe('auto:btn:30');
+      expect(result[0].channelName).toBe('음악 방');
+    });
+
+    it('buttonLabel과 configName 모두 null이면 "Config-{configId}" 형식의 이름을 사용한다', () => {
+      const recordWithNoNames = makeRecord({
+        channelId: 'auto-ch-401',
+        channelName: '방',
+        channelDurationSec: 300,
+        channelType: 'auto_select',
+        autoChannelConfigId: 7,
+        autoChannelConfigName: null,
+        autoChannelButtonId: 40,
+        autoChannelButtonLabel: null,
+      });
+
+      const result = computeChannelStats([recordWithNoNames], 'auto_grouped');
+
+      expect(result[0].channelName).toBe('Config-7');
+    });
+
+    it('buttonId가 null이면 "auto:cfg:{configId}" 키를 폴백으로 사용한다', () => {
+      const recordWithNullButtonId = makeRecord({
+        channelId: 'auto-ch-501',
+        channelName: '방',
+        channelDurationSec: 800,
+        channelType: 'auto_select',
+        autoChannelConfigId: 3,
+        autoChannelConfigName: '일반 방',
+        autoChannelButtonId: null,
+        autoChannelButtonLabel: null,
+      });
+
+      const result = computeChannelStats([recordWithNullButtonId], 'auto_grouped');
+
+      expect(result[0].channelId).toBe('auto:cfg:3');
+    });
+
+    it('buttonId가 있는 그룹과 없는 그룹(configId 폴백)이 함께 존재할 때 각각 독립적으로 집계된다', () => {
+      const withButton = makeRecord({
+        channelId: 'auto-ch-601',
+        channelName: '방',
+        channelDurationSec: 700,
+        channelType: 'auto_select',
+        autoChannelConfigId: 5,
+        autoChannelConfigName: '혼합 방',
+        autoChannelButtonId: 50,
+        autoChannelButtonLabel: '옵션A',
+      });
+      const withoutButton = makeRecord({
+        channelId: 'auto-ch-602',
+        channelName: '방',
+        channelDurationSec: 300,
+        channelType: 'auto_select',
+        autoChannelConfigId: 5,
+        autoChannelConfigName: '혼합 방',
+        autoChannelButtonId: null,
+        autoChannelButtonLabel: null,
+      });
+
+      const result = computeChannelStats([withButton, withoutButton], 'auto_grouped');
+
+      expect(result).toHaveLength(2);
+      expect(result.some((r) => r.channelId === 'auto:btn:50')).toBe(true);
+      expect(result.some((r) => r.channelId === 'auto:cfg:5')).toBe(true);
+    });
+  });
+
+  describe('computeAutoChannelGroupStats - button 단위', () => {
+    it('buttonId가 있으면 결과에 autoChannelButtonId와 autoChannelButtonLabel이 포함된다', () => {
+      const result = computeAutoChannelGroupStats([CONFIG1_BTN_A_INST1]);
+
+      expect(result[0].autoChannelButtonId).toBe(10);
+      expect(result[0].autoChannelButtonLabel).toBe('게임하기');
+    });
+
+    it('buttonId가 null이면 autoChannelButtonId가 null이다', () => {
+      const result = computeAutoChannelGroupStats([AUTO_CONFIG1_INSTANCE1]);
+
+      expect(result[0].autoChannelButtonId).toBeNull();
+      expect(result[0].autoChannelButtonLabel).toBeNull();
+    });
+
+    it('동일 configId 내 서로 다른 buttonId가 별도 그룹으로 집계된다', () => {
+      const result = computeAutoChannelGroupStats([
+        CONFIG1_BTN_A_INST1,
+        CONFIG1_BTN_A_INST2,
+        CONFIG1_BTN_B_INST1,
+      ]);
+
+      expect(result).toHaveLength(2);
+
+      const btnA = result.find((r) => r.autoChannelButtonId === 10);
+      const btnB = result.find((r) => r.autoChannelButtonId === 20);
+
+      expect(btnA).toBeDefined();
+      expect(btnB).toBeDefined();
+      expect(btnA?.totalDurationSec).toBe(1500); // 600 + 900
+      expect(btnB?.totalDurationSec).toBe(1200);
+    });
+
+    it('buttonLabel이 null이면 autoChannelButtonLabel이 null이다', () => {
+      const recordWithNullLabel = makeRecord({
+        channelId: 'auto-ch-701',
+        channelName: '방',
+        channelDurationSec: 400,
+        channelType: 'auto_select',
+        autoChannelConfigId: 8,
+        autoChannelConfigName: '테스트 방',
+        autoChannelButtonId: 60,
+        autoChannelButtonLabel: null,
+      });
+
+      const result = computeAutoChannelGroupStats([recordWithNullLabel]);
+
+      expect(result[0].autoChannelButtonId).toBe(60);
+      expect(result[0].autoChannelButtonLabel).toBeNull();
+    });
+
+    it('같은 buttonId를 가진 인스턴스들의 instanceCount가 고유 channelId 수와 일치한다', () => {
+      const result = computeAutoChannelGroupStats([CONFIG1_BTN_A_INST1, CONFIG1_BTN_A_INST2]);
+
+      expect(result[0].instanceCount).toBe(2); // auto-ch-101, auto-ch-102
+    });
+  });
+
+  describe('computeSummary - button 단위 uniqueChannels 카운트', () => {
+    it('동일 configId 내 서로 다른 buttonId는 별도 채널로 카운트된다', () => {
+      const records = [
+        GLOBAL_RECORD,
+        CONFIG1_BTN_A_INST1, // buttonId: 10
+        CONFIG1_BTN_A_INST2, // buttonId: 10 (동일)
+        CONFIG1_BTN_B_INST1, // buttonId: 20 (다름)
+      ];
+
+      const summary = computeSummary(records);
+
+      // 버튼 단위: btn:10, btn:20 = 2
+      expect(summary.uniqueChannels).toBe(2);
+    });
+
+    it('buttonId가 있는 레코드와 없는 레코드(configId 폴백)가 혼합될 때 각각 별도로 카운트된다', () => {
+      const withButton = makeRecord({
+        channelId: 'auto-ch-801',
+        channelName: '방',
+        channelDurationSec: 500,
+        channelType: 'auto_select',
+        autoChannelConfigId: 9,
+        autoChannelConfigName: '혼합',
+        autoChannelButtonId: 70,
+        autoChannelButtonLabel: '선택A',
+      });
+      const withoutButton = makeRecord({
+        channelId: 'auto-ch-802',
+        channelName: '방',
+        channelDurationSec: 300,
+        channelType: 'auto_select',
+        autoChannelConfigId: 9,
+        autoChannelConfigName: '혼합',
+        autoChannelButtonId: null,
+        autoChannelButtonLabel: null,
+      });
+
+      const summary = computeSummary([GLOBAL_RECORD, withButton, withoutButton]);
+
+      // btn:70, cfg:9 = 2
+      expect(summary.uniqueChannels).toBe(2);
+    });
   });
 });

--- a/apps/web/app/lib/voice-dashboard-api.ts
+++ b/apps/web/app/lib/voice-dashboard-api.ts
@@ -17,6 +17,8 @@ export interface VoiceDailyRecord {
   channelType?: 'permanent' | 'auto_select' | 'auto_instant';
   autoChannelConfigId?: number | null;
   autoChannelConfigName?: string | null;
+  autoChannelButtonId?: number | null;
+  autoChannelButtonLabel?: string | null;
 }
 
 /** 대시보드 요약 카드용 통계 */
@@ -62,6 +64,8 @@ export interface VoiceCategoryStat {
 export interface VoiceAutoChannelGroupStat {
   autoChannelConfigId: number;
   autoChannelConfigName: string;
+  autoChannelButtonId: number | null;
+  autoChannelButtonLabel: string | null;
   channelType: 'auto_select' | 'auto_instant';
   totalDurationSec: number;
   instanceCount: number; // 해당 config로 생성된 고유 channelId 수
@@ -125,9 +129,14 @@ export function computeSummary(records: VoiceDailyRecord[]): VoiceSummary {
   const permanentChannelIds = new Set(
     channelRecords.filter((r) => (r.autoChannelConfigId ?? null) == null).map((r) => r.channelId),
   );
-  // 자동방: configId 단위 카운트 (config 단위로 그룹핑)
-  const autoConfigIds = new Set(
-    channelRecords.filter((r) => r.autoChannelConfigId != null).map((r) => r.autoChannelConfigId),
+  // 자동방: buttonId ?? configId 단위 카운트 (button 단위 그룹핑)
+  const autoGroupKeys = new Set(
+    channelRecords
+      .filter((r) => r.autoChannelConfigId != null)
+      .map((r) => {
+        const buttonId = r.autoChannelButtonId ?? null;
+        return buttonId != null ? `btn:${buttonId}` : `cfg:${r.autoChannelConfigId}`;
+      }),
   );
 
   return {
@@ -136,7 +145,7 @@ export function computeSummary(records: VoiceDailyRecord[]): VoiceSummary {
     totalMicOffSec: globalRecords.reduce((sum, r) => sum + r.micOffSec, 0),
     totalAloneSec: globalRecords.reduce((sum, r) => sum + r.aloneSec, 0),
     uniqueUsers: userIds.size,
-    uniqueChannels: permanentChannelIds.size + autoConfigIds.size,
+    uniqueChannels: permanentChannelIds.size + autoGroupKeys.size,
   };
 }
 
@@ -215,14 +224,22 @@ export function computeChannelStats(
     return Array.from(byChannel.values()).sort((a, b) => b.totalDurationSec - a.totalDurationSec);
   }
 
-  // auto_grouped 모드: 자동방은 configId 단위로 합산, 상설 채널은 channelId 단위
+  // auto_grouped 모드: 자동방은 buttonId ?? configId 단위로 합산, 상설 채널은 channelId 단위
   const byKey = new Map<string, VoiceChannelStat>();
 
   for (const r of channelRecords) {
     const configId = r.autoChannelConfigId;
-    const key = configId != null ? `auto:${configId}` : r.channelId;
+    const buttonId = r.autoChannelButtonId ?? null;
+    const key =
+      configId != null
+        ? buttonId != null
+          ? `auto:btn:${buttonId}`
+          : `auto:cfg:${configId}`
+        : r.channelId;
     const name =
-      configId != null ? (r.autoChannelConfigName ?? `Config-${configId}`) : r.channelName;
+      configId != null
+        ? (r.autoChannelButtonLabel ?? r.autoChannelConfigName ?? `Config-${configId}`)
+        : r.channelName;
 
     const existing = byKey.get(key);
     if (existing) {
@@ -281,12 +298,14 @@ export function computeAutoChannelGroupStats(
     (r) => r.channelId !== 'GLOBAL' && (r.autoChannelConfigId ?? null) != null,
   );
 
-  const byConfig = new Map<number, { stat: VoiceAutoChannelGroupStat; channelIds: Set<string> }>();
+  const byGroup = new Map<string, { stat: VoiceAutoChannelGroupStat; channelIds: Set<string> }>();
 
   for (const r of channelRecords) {
     // filter 조건에서 autoChannelConfigId != null을 검증했으므로 안전한 단언
     const configId = r.autoChannelConfigId as number;
-    const existing = byConfig.get(configId);
+    const buttonId = r.autoChannelButtonId ?? null;
+    const groupKey = buttonId != null ? `btn:${buttonId}` : `cfg:${configId}`;
+    const existing = byGroup.get(groupKey);
     if (existing) {
       existing.stat.totalDurationSec += r.channelDurationSec;
       existing.channelIds.add(r.channelId);
@@ -294,10 +313,12 @@ export function computeAutoChannelGroupStats(
       // autoChannelConfigId가 있는 레코드는 auto_select 또는 auto_instant만 가능
       const channelType: 'auto_select' | 'auto_instant' =
         r.channelType === 'auto_instant' ? 'auto_instant' : 'auto_select';
-      byConfig.set(configId, {
+      byGroup.set(groupKey, {
         stat: {
           autoChannelConfigId: configId,
           autoChannelConfigName: r.autoChannelConfigName ?? `Config-${configId}`,
+          autoChannelButtonId: buttonId,
+          autoChannelButtonLabel: r.autoChannelButtonLabel ?? null,
           channelType,
           totalDurationSec: r.channelDurationSec,
           instanceCount: 0,
@@ -307,7 +328,7 @@ export function computeAutoChannelGroupStats(
     }
   }
 
-  return Array.from(byConfig.values())
+  return Array.from(byGroup.values())
     .map(({ stat, channelIds }) => ({ ...stat, instanceCount: channelIds.size }))
     .sort((a, b) => b.totalDurationSec - a.totalDurationSec);
 }

--- a/docs/archive/prd-changelog.md
+++ b/docs/archive/prd-changelog.md
@@ -7,6 +7,8 @@ PRD 본문(`/docs/specs/prd/*.md`)에는 변경이력을 직접 작성하지 않
 
 | 버전 | 날짜 | 변경 요약 | 작성자 |
 |------|------|-----------|--------|
+| v5.7 | 2026-04-04 | voice: 서버 진단 API 명세 신규 추가(F-VOICE-040~042) — 건강도 점수 공식 로그 커브 다차원 가중합산 개선, AI 진단 maxOutputTokens 1024 상향, 리더보드 avatarUrl GuildMemberService 조회 반영 | — |
+| v5.6 | 2026-04-04 | voice: 자동방 통계 그룹핑 단위 Config → Button 변경 — F-VOICE-032~038 수정, AutoChannelInfo에 buttonId/buttonLabel 추가, voice_daily 컬럼 2개 추가(autoChannelButtonId/autoChannelButtonLabel), 그룹핑 키를 buttonId ?? configId로 변경 | — |
 | v5.5 | 2026-04-04 | newbie: F-NEWBIE-002-CANVAS 신입 미션 Canvas 표시 모드 추가 — missionDisplayMode 설정, 여러 장 전송 방식, 테이블 레이아웃·프로그레스 바·D-day 색상, Redis 캐싱(TTL 30초) 명세 | — |
 | v5.4 | 2026-04-04 | newbie: missionTargetPlayCount(목표 플레이횟수) 설정 추가 — NewbieConfig·NewbieMission 데이터 모델 확장, 달성 판정 로직 변경(AND 조건), 항목 템플릿 변수 {targetPlayCount} 추가, 탭 2 UI 항목 추가, API 응답 필드 추가 | — |
 | v5.3 | 2026-04-04 | guild-member: 길드 멤버 중앙 관리 도메인 PRD 신규 추가 (F-GUILD-MEMBER-001~009), _index.md 도메인 목록·엔티티 테이블 갱신 | — |
@@ -52,6 +54,44 @@ PRD 본문(`/docs/specs/prd/*.md`)에는 변경이력을 직접 작성하지 않
 | v1.3 | 2026-03-08 | 게임방 상태 접두사(status-prefix) 도메인 PRD 신규 추가 | — |
 | v1.2 | 2026-03-08 | 신규사용자 관리(newbie) 도메인 PRD 신규 추가 | — |
 | v1.1 | 2026-03-08 | 자동방 생성(Auto Channel) 기능 추가 | — |
+
+---
+
+## [수정 44] voice: 서버 진단 API 명세 신규 추가 — 건강도 점수 공식 개선, AI 진단 토큰 상향, 리더보드 아바타 조회 수정 (VOICE-ANALYTICS-DIAGNOSIS-FIXES)
+
+**변경일**: 2026-04-04
+**티켓**: VOICE-ANALYTICS-DIAGNOSIS-FIXES
+
+**변경 파일**:
+- `docs/specs/prd/voice.md` — 서버 진단 API 섹션(F-VOICE-040~042) 신규 추가
+
+**변경 내용**:
+1. **F-VOICE-040 신규 추가**: `GET /voice-analytics/health-score` 백엔드 명세. 로그 커브 기반 다차원 가중합산 공식 — `normalize(value, midpoint) = 100 × value / (value + midpoint)` — 지표 4종(일평균 활성 유저 40% midpoint=10, 일평균 총 음성시간 30% midpoint=5h, 마이크 사용률 20% midpoint=30%, 활동일 비율 10% midpoint=50%). `calculateHealthScore()` 시그니처에 `dailyTrends` 파라미터 추가. 기존 선형 공식(`avgDailyUsers × 10 + dailyAvgHours × 5`) 폐기 이유 명시.
+2. **F-VOICE-041 신규 추가**: `GET /voice-analytics/health-diagnosis` 백엔드 명세. `generateHealthDiagnosis()`의 `maxOutputTokens: 1024` (기존 512에서 상향). 한국어 토큰 소모 특성으로 512 토큰에서 2~3문장 완성 전 잘림 문제 발생하여 상향.
+3. **F-VOICE-042 신규 추가**: `GET /voice-analytics/leaderboard` 백엔드 명세. `getLeaderboard()`가 페이징된 유저 ID에 대해 `GuildMemberService.findByUserIds()`를 호출하여 실제 아바타 URL을 응답에 포함. 기존 `avatarUrl: null` 하드코딩 문제 및 수정 사유 명시.
+
+**변경 사유**: 코드에 적용된 3가지 버그 수정 및 개선사항(리더보드 아바타 미노출 수정, AI 진단 텍스트 잘림 수정, 건강도 점수 항상 100점 문제 해결)이 PRD에 반영되어 있지 않아 명세를 추가하고 관련 백엔드 API 섹션을 신규 작성한다.
+
+---
+
+## [수정 43] voice: 자동방 통계 그룹핑 단위 Config → Button 변경 (VOICE-AUTO-BUTTON-GROUPING)
+
+**변경일**: 2026-04-04
+**티켓**: VOICE-AUTO-BUTTON-GROUPING
+
+**변경 파일**:
+- `docs/specs/prd/voice.md` — F-VOICE-032~038 수정 (자동방 그룹핑 단위를 AutoChannelConfig에서 AutoChannelButton으로 변경)
+
+**변경 내용**:
+1. F-VOICE-032: `AutoChannelInfo` 인터페이스에 `buttonId` (integer, nullable), `buttonLabel` (string, nullable) 필드 추가. Redis 저장 값 및 필드 테이블 갱신. 선택 모드 2지점에 `button.id`/`button.label` 전달, 즉시 모드 1지점에 null 전달 명세 추가
+2. F-VOICE-033: `voice_daily` 테이블에 `autoChannelButtonId` (integer, nullable), `autoChannelButtonLabel` (varchar(255), nullable) 컬럼 2개 추가. 마이그레이션 SQL 및 새 인덱스 `IDX_voice_daily_auto_button` 추가
+3. F-VOICE-034: Flush 로직에서 `buttonId`, `buttonLabel`을 추가 추출하여 `accumulateChannelDuration()`에 전달, UPSERT SQL에 버튼 컬럼 2개 포함 명세 추가
+4. F-VOICE-035: `VoiceDailyRecordDto` 및 `ChannelStatItem`에 `autoChannelButtonId`, `autoChannelButtonLabel` 필드 추가. API 응답 예시에 버튼 필드 포함
+5. F-VOICE-036: `groupAutoChannels=true` 시 그룹핑 키를 `autoChannelButtonId` 우선 → `autoChannelConfigId` 폴백으로 변경. 치환 채널명을 `buttonLabel` 우선 → `configName` 폴백으로 변경
+6. F-VOICE-037: `VoiceDailyRecord` 타입에 버튼 필드 2개 추가. `VoiceAutoChannelGroupStat`에 `autoChannelButtonId`, `autoChannelButtonLabel` 필드 추가. `computeAutoChannelGroupStats()` 및 `computeChannelStats('auto_grouped')`의 그룹 키를 `buttonId ?? configId`로 변경
+7. F-VOICE-038: "자동방 그룹" 탭 표시명을 `autoChannelButtonLabel` 우선 → `autoChannelConfigName` 폴백으로 변경. `SummaryCards`의 uniqueChannels 계산 기준을 button 단위로 변경. `UserChannelPieChart` 파이 슬라이스 기준 동일하게 변경. i18n 키 `voice.summary.autoChannelGroups`의 한국어 값을 "자동방 설정" → "자동방 버튼"으로 수정
+
+**변경 사유**: 같은 AutoChannelConfig에 속한 버튼(일반방, 게임방, 경쟁방 등)이 Config 이름으로 합산되는 문제를 해결하기 위해 그룹핑 단위를 Button 레벨로 세분화
 
 ---
 

--- a/docs/plans/auto-channel-button-grouping-backend.md
+++ b/docs/plans/auto-channel-button-grouping-backend.md
@@ -1,0 +1,541 @@
+# 자동방 그룹핑 단위 변경 (Config -> Button) -- 백엔드 구현 계획
+
+> 최종 업데이트: 2026-04-04
+> PRD 참조: F-VOICE-032 ~ F-VOICE-038
+
+## 개요
+
+기존 자동방 통계 그룹핑은 `autoChannelConfigId` 단위로만 합산한다. 같은 Config 안에 여러 Button이 있을 때 (예: "일반방", "랭크방") 이를 구분할 수 없는 문제가 있다.
+
+이 계획은 **buttonId/buttonLabel** 필드를 데이터 파이프라인 전체에 추가하고, 그룹핑 로직을 **buttonId 우선 / configId 폴백**(즉시 모드)으로 변경한다.
+
+### 변경 범위 요약
+
+| 레이어 | 변경 요약 |
+|--------|----------|
+| Redis 메타데이터 | `AutoChannelInfo`에 `buttonId`, `buttonLabel` 추가 |
+| Auto-channel 서비스 | 캐싱 호출 3곳에 button 정보 전달 |
+| voice_daily Entity | `autoChannelButtonId`, `autoChannelButtonLabel` 컬럼 (이미 완료) |
+| voice_daily Repository | UPSERT SQL에 2개 컬럼 추가 |
+| Flush 서비스 | Redis -> DB 전달 시 button 정보 주입 |
+| DTO/서비스 매핑 | `VoiceDailyRecordDto` + `VoiceDailyService` 확장 |
+| VoiceAnalyticsService | 그룹핑 키를 `buttonId` 우선으로 변경 |
+| 공유 타입 | `ChannelStatItem`에 button 필드 추가 |
+
+---
+
+## 구현 순서
+
+의존 관계에 따라 아래 순서로 구현한다:
+
+```
+Step 1: AutoChannelInfo 인터페이스 확장 (Redis)
+  |
+Step 2: auto-channel.service.ts 캐싱 호출 수정 (3곳)
+  |
+Step 3: voice-daily.repository.ts UPSERT SQL 확장
+  |
+Step 4: voice-daily-flush-service.ts button 정보 주입
+  |
+Step 5: VoiceDailyRecordDto + VoiceDailyService 매핑 확장
+  |
+Step 6: ChannelStatItem 공유 타입 확장
+  |
+Step 7: VoiceAnalyticsService 그룹핑 로직 변경
+```
+
+---
+
+## Step 1: AutoChannelInfo 인터페이스 확장
+
+**파일**: `apps/api/src/channel/voice/infrastructure/voice-redis.repository.ts`
+**변경 위치**: L8-12 (`AutoChannelInfo` 인터페이스)
+
+### 현재 코드
+
+```typescript
+export interface AutoChannelInfo {
+  configId: number;
+  configName: string;
+  channelType: 'auto_select' | 'auto_instant';
+}
+```
+
+### 변경 후
+
+```typescript
+export interface AutoChannelInfo {
+  configId: number;
+  configName: string;
+  channelType: 'auto_select' | 'auto_instant';
+  buttonId: number | null;
+  buttonLabel: string | null;
+}
+```
+
+### 주의사항
+
+- `setAutoChannelInfo()` / `getAutoChannelInfo()` 메서드는 제네릭 `AutoChannelInfo` 타입을 사용하므로 시그니처 변경 불필요
+- 기존에 Redis에 저장된 `AutoChannelInfo`에는 `buttonId`, `buttonLabel` 키가 없으므로, 조회 시 `undefined`로 반환됨. Flush 서비스에서 `?? null` 폴백 처리 필요 (Step 4에서 처리)
+
+---
+
+## Step 2: auto-channel.service.ts 캐싱 호출 수정
+
+**파일**: `apps/api/src/channel/auto/application/auto-channel.service.ts`
+
+### 2-1. `cacheAutoChannelInfo()` private 메서드 시그니처 확장
+
+**변경 위치**: L768-786
+
+현재:
+```typescript
+private async cacheAutoChannelInfo({
+  guildId,
+  channelId,
+  configId,
+  configName,
+  channelType,
+}: {
+  guildId: string;
+  channelId: string;
+  configId: number;
+  configName: string;
+  channelType: 'auto_select' | 'auto_instant';
+}): Promise<void> {
+  await this.voiceRedisRepository.setAutoChannelInfo(guildId, channelId, {
+    configId,
+    configName,
+    channelType,
+  });
+}
+```
+
+변경 후:
+```typescript
+private async cacheAutoChannelInfo({
+  guildId,
+  channelId,
+  configId,
+  configName,
+  channelType,
+  buttonId,
+  buttonLabel,
+}: {
+  guildId: string;
+  channelId: string;
+  configId: number;
+  configName: string;
+  channelType: 'auto_select' | 'auto_instant';
+  buttonId: number | null;
+  buttonLabel: string | null;
+}): Promise<void> {
+  await this.voiceRedisRepository.setAutoChannelInfo(guildId, channelId, {
+    configId,
+    configName,
+    channelType,
+    buttonId,
+    buttonLabel,
+  });
+}
+```
+
+### 2-2. 호출 지점 1 -- `confirmChannel()` (select 모드)
+
+**변경 위치**: L330-336
+
+```typescript
+await this.cacheAutoChannelInfo({
+  guildId,
+  channelId: confirmedChannelId,
+  configId: button.configId,
+  configName: button.config.name,
+  channelType: 'auto_select',
+  buttonId: button.id,        // 추가
+  buttonLabel: button.label,   // 추가
+});
+```
+
+### 2-3. 호출 지점 2 -- `createAndMoveToConfirmedChannel()` (select 모드, bot 경유)
+
+**변경 위치**: L634-640
+
+```typescript
+await this.cacheAutoChannelInfo({
+  guildId,
+  channelId: confirmedChannelId,
+  configId: button.configId,
+  configName: button.config.name,
+  channelType: 'auto_select',
+  buttonId: button.id,        // 추가
+  buttonLabel: button.label,   // 추가
+});
+```
+
+### 2-4. 호출 지점 3 -- `handleInstantTriggerJoin()` (instant 모드)
+
+**변경 위치**: L732-738
+
+```typescript
+await this.cacheAutoChannelInfo({
+  guildId,
+  channelId: confirmedChannelId,
+  configId: config.id,
+  configName: config.name,
+  channelType: 'auto_instant',
+  buttonId: null,              // 추가 (즉시 모드는 버튼 없음)
+  buttonLabel: null,           // 추가
+});
+```
+
+### 주의사항
+
+- `button.label`은 `AutoChannelButtonOrm.label` (string, non-nullable) 이므로 null 체크 불필요
+- `button.id`는 `AutoChannelButtonOrm.id` (number, PK) 이므로 항상 존재
+
+---
+
+## Step 3: voice-daily.repository.ts UPSERT SQL 확장
+
+**파일**: `apps/api/src/channel/voice/infrastructure/voice-daily.repository.ts`
+**변경 위치**: L7-22 (인터페이스), L38-91 (UPSERT 메서드)
+
+### 3-1. AccumulateChannelDurationParams 인터페이스 확장
+
+L20-21 뒤에 추가:
+```typescript
+autoChannelButtonId?: number | null;
+autoChannelButtonLabel?: string | null;
+```
+
+### 3-2. accumulateChannelDuration() 메서드 변경
+
+파라미터 destructuring (L39-52)에 추가:
+```typescript
+const {
+  // ... 기존 필드
+  autoChannelButtonId = null,
+  autoChannelButtonLabel = null,
+} = params;
+```
+
+INSERT SQL (L56-59) 변경 -- 컬럼 목록에 2개 추가:
+```sql
+INSERT INTO voice_daily AS vd
+    ("guildId","userId","userName","date","channelId","channelName","channelDurationSec","categoryId","categoryName","recordedAt",
+     "channelType","autoChannelConfigId","autoChannelConfigName","autoChannelButtonId","autoChannelButtonLabel")
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+```
+
+ON CONFLICT DO UPDATE SET (L73-74 뒤에 추가):
+```sql
+"autoChannelButtonId"    = COALESCE(vd."autoChannelButtonId",    EXCLUDED."autoChannelButtonId"),
+"autoChannelButtonLabel" = COALESCE(vd."autoChannelButtonLabel", EXCLUDED."autoChannelButtonLabel")
+```
+
+파라미터 배열 (L76-91) 변경 -- 2개 추가:
+```typescript
+[
+  guildId, userId, userName, date, channelId, channelName,
+  durationSec, categoryId, categoryName, recordedAt,
+  channelType, autoChannelConfigId, autoChannelConfigName,
+  autoChannelButtonId, autoChannelButtonLabel,   // $14, $15
+]
+```
+
+### 주의사항
+
+- `COALESCE(vd."autoChannelButtonId", EXCLUDED."autoChannelButtonId")` 패턴으로 기존 값 우선 보존 (configId/configName과 동일한 전략)
+- 파라미터 인덱스가 `$13`에서 `$15`까지 늘어남
+
+---
+
+## Step 4: voice-daily-flush-service.ts button 정보 주입
+
+**파일**: `apps/api/src/channel/voice/application/voice-daily-flush-service.ts`
+**변경 위치**: L54-67 (`accumulateChannelDuration` 호출 부분)
+
+### 변경 내용
+
+기존 호출에 `autoChannelButtonId`, `autoChannelButtonLabel` 2개 필드 추가:
+
+```typescript
+await this.voiceDailyRepository.accumulateChannelDuration({
+  guildId: guild,
+  userId: user,
+  userName,
+  date,
+  channelId,
+  channelName,
+  durationSec: duration,
+  categoryId: categoryInfo?.categoryId ?? null,
+  categoryName: categoryInfo?.categoryName ?? null,
+  channelType: autoChannelInfo?.channelType ?? 'permanent',
+  autoChannelConfigId: autoChannelInfo?.configId ?? null,
+  autoChannelConfigName: autoChannelInfo?.configName ?? null,
+  autoChannelButtonId: autoChannelInfo?.buttonId ?? null,      // 추가
+  autoChannelButtonLabel: autoChannelInfo?.buttonLabel ?? null, // 추가
+});
+```
+
+### 주의사항
+
+- 기존 Redis에 저장된 `AutoChannelInfo`에 `buttonId`/`buttonLabel`이 없으면 `undefined`로 반환되므로, `?? null` 폴백이 필수
+- Step 1에서 Redis 롤링 업데이트 동안 기존 캐시와 신규 캐시가 혼재할 수 있지만, `?? null` 폴백으로 안전하게 처리됨
+
+---
+
+## Step 5: VoiceDailyRecordDto + VoiceDailyService 매핑 확장
+
+### 5-1. VoiceDailyRecordDto
+
+**파일**: `apps/api/src/channel/voice/dto/voice-daily-record.dto.ts`
+**변경 위치**: L16-17 (마지막 필드 뒤)
+
+추가:
+```typescript
+autoChannelButtonId: number | null;
+autoChannelButtonLabel: string | null;
+```
+
+### 5-2. VoiceDailyService 매핑
+
+**파일**: `apps/api/src/channel/voice/application/voice-daily.service.ts`
+**변경 위치**: L38-39 (매핑 객체의 마지막 필드 뒤)
+
+추가:
+```typescript
+autoChannelButtonId: e.autoChannelButtonId ?? null,
+autoChannelButtonLabel: e.autoChannelButtonLabel ?? null,
+```
+
+---
+
+## Step 6: ChannelStatItem 공유 타입 확장
+
+**파일**: `libs/shared/src/types/diagnosis.ts`
+**변경 위치**: L37-47 (`ChannelStatItem` 인터페이스)
+
+### 변경 후
+
+```typescript
+export interface ChannelStatItem {
+  channelId: string;
+  channelName: string;
+  categoryId: string | null;
+  categoryName: string | null;
+  totalSec: number;
+  uniqueUsers: number;
+  channelType: 'permanent' | 'auto_select' | 'auto_instant';
+  autoChannelConfigId: number | null;
+  autoChannelConfigName: string | null;
+  autoChannelButtonId: number | null;      // 추가
+  autoChannelButtonLabel: string | null;   // 추가
+}
+```
+
+### 주의사항
+
+- 이 타입은 `@onyu/shared` 패키지에 있으므로, 프론트엔드에서도 참조됨
+- 프론트엔드 빌드 시 자동으로 새 필드가 반영됨
+
+---
+
+## Step 7: VoiceAnalyticsService 그룹핑 로직 변경
+
+**파일**: `apps/api/src/voice-analytics/application/voice-analytics.service.ts`
+
+### 7-1. ChannelStatAggregate 인터페이스 확장
+
+**변경 위치**: L29-39
+
+추가 필드:
+```typescript
+autoChannelButtonId: number | null;
+autoChannelButtonLabel: string | null;
+```
+
+### 7-2. getChannelStats() 채널 집계 루프 확장
+
+**변경 위치**: L478-496
+
+기존 `chMap` 초기화 및 업데이트 코드에 button 필드 추가:
+
+초기화 시:
+```typescript
+const existing = chMap.get(r.channelId) ?? {
+  // ... 기존 필드
+  autoChannelButtonId: r.autoChannelButtonId ?? null,
+  autoChannelButtonLabel: r.autoChannelButtonLabel ?? null,
+};
+```
+
+업데이트 시 (L494-495 뒤):
+```typescript
+if (r.autoChannelButtonId) existing.autoChannelButtonId = r.autoChannelButtonId;
+if (r.autoChannelButtonLabel) existing.autoChannelButtonLabel = r.autoChannelButtonLabel;
+```
+
+### 7-3. 그룹핑 결과 매핑에 button 필드 추가
+
+**변경 위치**: L527-538 (`groupByAutoChannelConfig` 메서드의 return 문)
+
+```typescript
+return Array.from(resultMap.entries())
+  .map(([channelId, ch]) => ({
+    channelId,
+    channelName: ch.channelName,
+    categoryId: ch.categoryId,
+    categoryName: ch.categoryName,
+    channelType: ch.channelType,
+    autoChannelConfigId: ch.autoChannelConfigId,
+    autoChannelConfigName: ch.autoChannelConfigName,
+    autoChannelButtonId: ch.autoChannelButtonId,        // 추가
+    autoChannelButtonLabel: ch.autoChannelButtonLabel,   // 추가
+    totalSec: ch.totalSec,
+    uniqueUsers: ch.uniqueUsers.size,
+  }))
+  .sort((a, b) => b.totalSec - a.totalSec);
+```
+
+### 7-4. buildGroupedResultMap() 그룹핑 키 변경 (핵심 변경)
+
+**변경 위치**: L542-578
+
+**현재 로직**: `autoChannelConfigId`가 있으면 `auto:{configId}`로 그룹핑
+**변경 로직**: `autoChannelButtonId`가 있으면 `auto:button:{buttonId}`로, 없으면(즉시 모드) `auto:config:{configId}`로 폴백
+
+```typescript
+private buildGroupedResultMap(
+  chMap: Map<string, ChannelStatAggregate>,
+): Map<string, ChannelStatAggregate> {
+  const resultMap = new Map<string, ChannelStatAggregate>();
+
+  for (const [channelId, ch] of chMap) {
+    if (ch.autoChannelConfigId == null) {
+      // 상설 채널: 그대로 유지
+      resultMap.set(channelId, { ...ch });
+      continue;
+    }
+
+    // 자동방: buttonId 우선, configId 폴백 (즉시 모드)
+    const groupKey = ch.autoChannelButtonId != null
+      ? `auto:button:${ch.autoChannelButtonId}`
+      : `auto:config:${ch.autoChannelConfigId}`;
+
+    const existing = resultMap.get(groupKey);
+
+    if (existing) {
+      existing.totalSec += ch.totalSec;
+      for (const userId of ch.uniqueUsers) {
+        existing.uniqueUsers.add(userId);
+      }
+    } else {
+      // 표시명: buttonLabel 우선, configName 폴백, channelName 최종 폴백
+      const displayName = ch.autoChannelButtonLabel
+        ?? ch.autoChannelConfigName
+        ?? ch.channelName;
+
+      resultMap.set(groupKey, {
+        channelName: displayName,
+        categoryId: ch.categoryId,
+        categoryName: ch.categoryName,
+        channelType: ch.channelType,
+        autoChannelConfigId: ch.autoChannelConfigId,
+        autoChannelConfigName: ch.autoChannelConfigName,
+        autoChannelButtonId: ch.autoChannelButtonId,
+        autoChannelButtonLabel: ch.autoChannelButtonLabel,
+        totalSec: ch.totalSec,
+        uniqueUsers: new Set(ch.uniqueUsers),
+      });
+    }
+  }
+
+  return resultMap;
+}
+```
+
+### 7-5. 비그룹핑 결과 매핑에도 button 필드 추가
+
+**변경 위치**: L503-515 (`getChannelStats()`의 비그룹핑 return 문)
+
+```typescript
+return Array.from(chMap.entries())
+  .map(([channelId, ch]) => ({
+    channelId,
+    channelName: ch.channelName,
+    categoryId: ch.categoryId,
+    categoryName: ch.categoryName,
+    totalSec: ch.totalSec,
+    uniqueUsers: ch.uniqueUsers.size,
+    channelType: ch.channelType,
+    autoChannelConfigId: ch.autoChannelConfigId,
+    autoChannelConfigName: ch.autoChannelConfigName,
+    autoChannelButtonId: ch.autoChannelButtonId,        // 추가
+    autoChannelButtonLabel: ch.autoChannelButtonLabel,   // 추가
+  }))
+  .sort((a, b) => b.totalSec - a.totalSec);
+```
+
+### 7-6. aggregateChannelStats() (collectVoiceActivityData 내부)에도 동일 적용
+
+**변경 위치**: L230-275
+
+`ChannelAggregate` 인터페이스 (L16-27)에 필드 추가:
+```typescript
+autoChannelButtonId: number | null;
+autoChannelButtonLabel: string | null;
+```
+
+`aggregateChannelStats()` 내부 channelMap 초기화 (L235-247)에 추가:
+```typescript
+autoChannelButtonId: record.autoChannelButtonId ?? null,
+autoChannelButtonLabel: record.autoChannelButtonLabel ?? null,
+```
+
+업데이트 로직 (L258-259 뒤):
+```typescript
+if (record.autoChannelButtonId) channel.autoChannelButtonId = record.autoChannelButtonId;
+if (record.autoChannelButtonLabel) channel.autoChannelButtonLabel = record.autoChannelButtonLabel;
+```
+
+---
+
+## DB 마이그레이션
+
+**voice_daily ORM Entity**는 이미 `autoChannelButtonId`, `autoChannelButtonLabel` 컬럼이 추가 완료되어 있다.
+
+마이그레이션 SQL (기존 마이그레이션에 추가 또는 신규 마이그레이션 생성):
+
+```sql
+ALTER TABLE voice_daily
+  ADD COLUMN IF NOT EXISTS "autoChannelButtonId" INTEGER NULL,
+  ADD COLUMN IF NOT EXISTS "autoChannelButtonLabel" VARCHAR(255) NULL;
+
+-- 버튼 단위 그룹핑 조회 최적화 인덱스
+CREATE INDEX IF NOT EXISTS "IDX_voice_daily_auto_button"
+  ON voice_daily ("guildId", "autoChannelButtonId", "date")
+  WHERE "autoChannelButtonId" IS NOT NULL;
+```
+
+---
+
+## 전체 파일 변경 요약
+
+| # | 파일 | Step | 변경 내용 |
+|---|------|------|----------|
+| 1 | `apps/api/src/channel/voice/infrastructure/voice-redis.repository.ts` | 1 | `AutoChannelInfo` 인터페이스에 `buttonId`, `buttonLabel` 추가 |
+| 2 | `apps/api/src/channel/auto/application/auto-channel.service.ts` | 2 | `cacheAutoChannelInfo()` 시그니처 확장 + 호출 3곳에 button 정보 전달 |
+| 3 | `apps/api/src/channel/voice/infrastructure/voice-daily.repository.ts` | 3 | `AccumulateChannelDurationParams` 확장 + UPSERT SQL 2개 컬럼 추가 |
+| 4 | `apps/api/src/channel/voice/application/voice-daily-flush-service.ts` | 4 | `accumulateChannelDuration()` 호출에 `buttonId`, `buttonLabel` 전달 |
+| 5 | `apps/api/src/channel/voice/dto/voice-daily-record.dto.ts` | 5 | DTO에 2개 필드 추가 |
+| 6 | `apps/api/src/channel/voice/application/voice-daily.service.ts` | 5 | Entity -> DTO 매핑에 2개 필드 추가 |
+| 7 | `libs/shared/src/types/diagnosis.ts` | 6 | `ChannelStatItem`에 2개 필드 추가 |
+| 8 | `apps/api/src/voice-analytics/application/voice-analytics.service.ts` | 7 | `ChannelStatAggregate`/`ChannelAggregate` 확장 + 그룹핑 키를 buttonId 우선으로 변경 |
+
+## 하위 호환성
+
+- **Redis**: 기존 캐시에 `buttonId`/`buttonLabel`이 없으면 `undefined`로 반환. Flush 서비스에서 `?? null`로 안전 처리
+- **DB**: 새 컬럼은 nullable이므로 기존 레코드는 null 유지. `COALESCE`로 기존 값 우선 보존
+- **API**: 새 필드는 nullable이므로 기존 클라이언트가 무시 가능
+- **그룹핑**: `buttonId`가 null인 레코드(즉시 모드 및 레거시)는 `configId` 폴백으로 기존 동작 유지

--- a/docs/plans/voice-auto-channel-grouping-button-unit-frontend.md
+++ b/docs/plans/voice-auto-channel-grouping-button-unit-frontend.md
@@ -1,0 +1,313 @@
+# 자동방 그룹핑 단위 변경 (Config -> Button) - 프론트엔드 구현 계획
+
+> PRD 참조: F-VOICE-037, F-VOICE-038
+> 선행 계획: [voice-auto-channel-grouping-frontend.md](./voice-auto-channel-grouping-frontend.md)
+> 작성일: 2026-04-04
+
+---
+
+## 배경
+
+기존 구현은 자동방 그룹핑을 `autoChannelConfigId` 단위로 수행한다. 하나의 Config에 여러 버튼이 존재할 수 있으므로, 버튼 단위로 세분화된 통계를 제공하기 위해 그룹핑 키를 `buttonId ?? configId`로 변경한다. 즉시 모드(auto_instant)는 button이 없으므로 기존처럼 configId로 폴백한다.
+
+---
+
+## 구현 단계
+
+### 단계 1: 타입 확장
+
+**파일**: `apps/web/app/lib/voice-dashboard-api.ts`
+
+#### 1-1. VoiceDailyRecord 인터페이스 (라인 4-20)
+
+기존 필드 뒤에 2개 필드를 추가한다.
+
+```diff
+ export interface VoiceDailyRecord {
+   // ... 기존 필드
+   autoChannelConfigId?: number | null;
+   autoChannelConfigName?: string | null;
++  autoChannelButtonId?: number | null;
++  autoChannelButtonLabel?: string | null;
+ }
+```
+
+**변경 위치**: 라인 19 (`autoChannelConfigName`) 뒤에 삽입
+**주의**: optional(`?`)과 `| null` 모두 유지하여 백엔드 미배포 시 하위 호환 보장
+
+#### 1-2. VoiceAutoChannelGroupStat 인터페이스 (라인 62-68)
+
+button 관련 필드 2개를 추가한다.
+
+```diff
+ export interface VoiceAutoChannelGroupStat {
+   autoChannelConfigId: number;
+   autoChannelConfigName: string;
++  autoChannelButtonId: number | null;
++  autoChannelButtonLabel: string | null;
+   channelType: 'auto_select' | 'auto_instant';
+   totalDurationSec: number;
+   instanceCount: number;
+ }
+```
+
+**변경 위치**: 라인 64 (`autoChannelConfigName`) 뒤에 삽입
+
+---
+
+### 단계 2: 집계 함수 변경
+
+**파일**: `apps/web/app/lib/voice-dashboard-api.ts`
+
+#### 2-1. computeAutoChannelGroupStats() (라인 277-313)
+
+그룹 키를 `configId` -> `buttonId ?? configId`로 변경하고, 표시명도 `buttonLabel ?? configName`으로 변경한다.
+
+**변경 전** (라인 284):
+```typescript
+const byConfig = new Map<number, { stat: VoiceAutoChannelGroupStat; channelIds: Set<string> }>();
+```
+
+**변경 후**:
+```typescript
+const byGroup = new Map<string, { stat: VoiceAutoChannelGroupStat; channelIds: Set<string> }>();
+```
+
+**변경 전** (라인 288-289):
+```typescript
+    const configId = r.autoChannelConfigId as number;
+    const existing = byConfig.get(configId);
+```
+
+**변경 후**:
+```typescript
+    const configId = r.autoChannelConfigId as number;
+    const buttonId = r.autoChannelButtonId ?? null;
+    const groupKey = buttonId != null ? `btn:${buttonId}` : `cfg:${configId}`;
+    const existing = byGroup.get(groupKey);
+```
+
+**변경 전** (라인 290-306):
+```typescript
+    if (existing) {
+      existing.stat.totalDurationSec += r.channelDurationSec;
+      existing.channelIds.add(r.channelId);
+    } else {
+      const channelType: 'auto_select' | 'auto_instant' =
+        r.channelType === 'auto_instant' ? 'auto_instant' : 'auto_select';
+      byConfig.set(configId, {
+        stat: {
+          autoChannelConfigId: configId,
+          autoChannelConfigName: r.autoChannelConfigName ?? `Config-${configId}`,
+          channelType,
+          totalDurationSec: r.channelDurationSec,
+          instanceCount: 0,
+        },
+        channelIds: new Set([r.channelId]),
+      });
+    }
+```
+
+**변경 후**:
+```typescript
+    if (existing) {
+      existing.stat.totalDurationSec += r.channelDurationSec;
+      existing.channelIds.add(r.channelId);
+    } else {
+      const channelType: 'auto_select' | 'auto_instant' =
+        r.channelType === 'auto_instant' ? 'auto_instant' : 'auto_select';
+      byGroup.set(groupKey, {
+        stat: {
+          autoChannelConfigId: configId,
+          autoChannelConfigName: r.autoChannelConfigName ?? `Config-${configId}`,
+          autoChannelButtonId: buttonId,
+          autoChannelButtonLabel: r.autoChannelButtonLabel ?? null,
+          channelType,
+          totalDurationSec: r.channelDurationSec,
+          instanceCount: 0,
+        },
+        channelIds: new Set([r.channelId]),
+      });
+    }
+```
+
+**변경 전** (라인 310-312):
+```typescript
+  return Array.from(byConfig.values())
+    .map(({ stat, channelIds }) => ({ ...stat, instanceCount: channelIds.size }))
+    .sort((a, b) => b.totalDurationSec - a.totalDurationSec);
+```
+
+**변경 후**:
+```typescript
+  return Array.from(byGroup.values())
+    .map(({ stat, channelIds }) => ({ ...stat, instanceCount: channelIds.size }))
+    .sort((a, b) => b.totalDurationSec - a.totalDurationSec);
+```
+
+#### 2-2. computeChannelStats() — auto_grouped 모드 (라인 218-246)
+
+그룹 키와 표시명을 button 우선으로 변경한다.
+
+**변경 전** (라인 222-225):
+```typescript
+    const configId = r.autoChannelConfigId;
+    const key = configId != null ? `auto:${configId}` : r.channelId;
+    const name =
+      configId != null ? (r.autoChannelConfigName ?? `Config-${configId}`) : r.channelName;
+```
+
+**변경 후**:
+```typescript
+    const configId = r.autoChannelConfigId;
+    const buttonId = r.autoChannelButtonId ?? null;
+    const key = configId != null
+      ? (buttonId != null ? `auto:btn:${buttonId}` : `auto:cfg:${configId}`)
+      : r.channelId;
+    const name = configId != null
+      ? (r.autoChannelButtonLabel ?? r.autoChannelConfigName ?? `Config-${configId}`)
+      : r.channelName;
+```
+
+**주의**: `auto:` 접두사는 유지한다. `UserChannelPieChart`에서 `ch.channelId.startsWith('auto:')` 필터를 사용하고 있으므로, 접두사 규칙을 깨면 안 된다 (라인 135 참조).
+
+---
+
+### 단계 3: SummaryCards uniqueChannels 계산 변경
+
+**파일**: `apps/web/app/lib/voice-dashboard-api.ts`
+
+#### 3-1. computeSummary() (라인 118-141)
+
+**변경 전** (라인 129-131):
+```typescript
+  const autoConfigIds = new Set(
+    channelRecords.filter((r) => r.autoChannelConfigId != null).map((r) => r.autoChannelConfigId),
+  );
+```
+
+**변경 후**:
+```typescript
+  // 자동방: buttonId ?? configId 단위 카운트 (button 단위 그룹핑)
+  const autoGroupKeys = new Set(
+    channelRecords
+      .filter((r) => r.autoChannelConfigId != null)
+      .map((r) => {
+        const buttonId = r.autoChannelButtonId ?? null;
+        return buttonId != null ? `btn:${buttonId}` : `cfg:${r.autoChannelConfigId}`;
+      }),
+  );
+```
+
+**변경 전** (라인 139):
+```typescript
+    uniqueChannels: permanentChannelIds.size + autoConfigIds.size,
+```
+
+**변경 후**:
+```typescript
+    uniqueChannels: permanentChannelIds.size + autoGroupKeys.size,
+```
+
+---
+
+### 단계 4: ChannelBarChart 차트 데이터 표시명 변경
+
+**파일**: `apps/web/app/dashboard/guild/[guildId]/voice/components/ChannelBarChart.tsx`
+
+#### 4-1. autoGroupChartData name 변경 (라인 89-94)
+
+**변경 전** (라인 89-94):
+```typescript
+  const autoGroupChartData = autoGroupStats.slice(0, 10).map((d) => ({
+    name: d.autoChannelConfigName,
+    durationMin: Math.round(d.totalDurationSec / 60),
+    micOnMin: 0,
+    micOffMin: 0,
+  }));
+```
+
+**변경 후**:
+```typescript
+  const autoGroupChartData = autoGroupStats.slice(0, 10).map((d) => ({
+    name: d.autoChannelButtonLabel ?? d.autoChannelConfigName,
+    durationMin: Math.round(d.totalDurationSec / 60),
+    micOnMin: 0,
+    micOffMin: 0,
+  }));
+```
+
+---
+
+### 단계 5: i18n 변경
+
+#### 5-1. 한국어 (libs/i18n/locales/ko/web/dashboard.json)
+
+**변경 위치**: 라인 71 `voice.summary.autoChannelGroups`
+
+```diff
+-      "autoChannelGroups": "자동방 설정"
++      "autoChannelGroups": "자동방 버튼"
+```
+
+#### 5-2. 영어 (libs/i18n/locales/en/web/dashboard.json)
+
+**변경 위치**: 라인 72 `voice.summary.autoChannelGroups`
+
+```diff
+-      "autoChannelGroups": "Auto Configs"
++      "autoChannelGroups": "Auto Channel Buttons"
+```
+
+---
+
+### 단계 6: UserChannelPieChart (자동 반영 확인)
+
+**파일**: `apps/web/app/dashboard/guild/[guildId]/voice/components/UserChannelPieChart.tsx`
+
+이 컴포넌트는 `autoGroupedChannelStats` prop을 받아 사용하며 (라인 133-142), 이 데이터는 부모 컴포넌트에서 `computeChannelStats(records, 'auto_grouped')` 호출 결과이다. 단계 2-2에서 이 함수의 그룹핑 키와 표시명을 이미 변경했으므로, 이 컴포넌트는 **별도 수정 불필요**하다.
+
+다만 `ch.channelId.startsWith('auto:')` 필터 (라인 135)가 정상 동작하는지 확인 필요:
+- 변경 후 키 형식: `auto:btn:{buttonId}` 또는 `auto:cfg:{configId}` -> `auto:` 접두사 유지되므로 정상 동작
+
+---
+
+## 변경 파일 요약
+
+| 파일 | 단계 | 변경 요약 |
+|------|------|----------|
+| `apps/web/app/lib/voice-dashboard-api.ts` | 1, 2, 3 | VoiceDailyRecord에 button 필드 2개 추가, VoiceAutoChannelGroupStat에 button 필드 2개 추가, computeAutoChannelGroupStats() 그룹 키 변경, computeChannelStats() auto_grouped 모드 키 변경, computeSummary() uniqueChannels 키 변경 |
+| `apps/web/app/dashboard/guild/[guildId]/voice/components/ChannelBarChart.tsx` | 4 | autoGroupChartData의 name을 buttonLabel 우선 폴백으로 변경 |
+| `apps/web/app/dashboard/guild/[guildId]/voice/components/SummaryCards.tsx` | - | 변경 없음 (computeSummary 내부 변경으로 자동 반영) |
+| `apps/web/app/dashboard/guild/[guildId]/voice/components/UserChannelPieChart.tsx` | 6 | 변경 없음 (computeChannelStats 변경으로 자동 반영, auto: 접두사 호환 확인) |
+| `libs/i18n/locales/ko/web/dashboard.json` | 5 | voice.summary.autoChannelGroups: "자동방 설정" -> "자동방 버튼" |
+| `libs/i18n/locales/en/web/dashboard.json` | 5 | voice.summary.autoChannelGroups: "Auto Configs" -> "Auto Channel Buttons" |
+
+---
+
+## 구현 순서
+
+```
+1. 타입 확장 (VoiceDailyRecord, VoiceAutoChannelGroupStat)
+   ↓
+2. 집계 함수 변경 (computeAutoChannelGroupStats, computeChannelStats)
+   ↓
+3. computeSummary uniqueChannels 변경
+   ↓
+4. ChannelBarChart 표시명 변경
+   ↓ (병렬 가능)
+5. i18n 변경 (ko, en)
+6. UserChannelPieChart 자동 반영 확인
+```
+
+---
+
+## 주의사항
+
+1. **auto: 접두사 호환**: `computeChannelStats()` auto_grouped 모드에서 키를 `auto:btn:{id}` / `auto:cfg:{id}` 형식으로 생성한다. `UserChannelPieChart`에서 `startsWith('auto:')` 필터를 사용하므로, 이 접두사 규칙을 반드시 유지해야 한다.
+
+2. **하위 호환**: 백엔드가 아직 `autoChannelButtonId` / `autoChannelButtonLabel`을 반환하지 않는 경우, 값이 `undefined`이므로 `?? null` 폴백으로 기존 configId 기반 그룹핑과 동일한 결과를 반환한다.
+
+3. **즉시 모드(auto_instant) 처리**: 즉시 모드는 button 없이 config 직접 생성이므로 `autoChannelButtonId`가 항상 `null`이다. 그룹 키가 `cfg:{configId}`로 폴백되어 기존 동작과 동일하다.
+
+4. **그룹 키 중복 불가**: 같은 configId에 속하는 서로 다른 buttonId는 별도 그룹으로 분리된다. 이것이 이번 변경의 핵심 목적이다.

--- a/docs/specs/database/_index.md
+++ b/docs/specs/database/_index.md
@@ -550,6 +550,8 @@ F-VOICE-020 쿼리는 `WHERE member.discordMemberId = ? AND channel.guildId = ?`
 | `channelType` | `varchar(20)` | NOT NULL, DEFAULT `'permanent'` | 채널 유형. `'permanent'`(일반 고정 채널) \| `'auto_select'`(자동방 선택 모드) \| `'auto_instant'`(자동방 즉시 모드) |
 | `autoChannelConfigId` | `int` | NULLABLE | `auto_channel_config.id`에 대한 논리적 참조. FK 제약 없음 — config 삭제 후에도 통계 보존 |
 | `autoChannelConfigName` | `varchar(255)` | NULLABLE | config.name 스냅샷. config 삭제 후에도 표시명 유지 |
+| `autoChannelButtonId` | `integer` | NULLABLE | `auto_channel_button.id`에 대한 논리적 참조. FK 제약 없음 — button 삭제 후에도 통계 보존. `auto_instant` 모드는 null |
+| `autoChannelButtonLabel` | `varchar(255)` | NULLABLE | button.label 스냅샷. button 삭제 후에도 표시명 유지. `auto_instant` 모드는 null |
 
 - **복합 PK**: `(guildId, userId, date, channelId)`
 - **테이블명**: `voice_daily` (커스텀 지정)
@@ -569,10 +571,13 @@ ALTER TABLE voice_daily
 #### 마이그레이션 (Phase 2 — F-VOICE-032~039)
 
 ```sql
+-- 1776400000000-AddAutoChannelGrouping
 ALTER TABLE voice_daily
-  ADD COLUMN "channelType"           varchar(20)  NOT NULL DEFAULT 'permanent',
-  ADD COLUMN "autoChannelConfigId"   int          NULL,
-  ADD COLUMN "autoChannelConfigName" varchar(255) NULL;
+  ADD COLUMN "channelType"            varchar(20)  NOT NULL DEFAULT 'permanent',
+  ADD COLUMN "autoChannelConfigId"    int          NULL,
+  ADD COLUMN "autoChannelConfigName"  varchar(255) NULL,
+  ADD COLUMN "autoChannelButtonId"    integer      NULL,
+  ADD COLUMN "autoChannelButtonLabel" varchar(255) NULL;
 
 -- 자동방 config 단위 그룹핑 조회 최적화 (partial index)
 CREATE INDEX "IDX_voice_daily_auto_config"
@@ -583,9 +588,14 @@ CREATE INDEX "IDX_voice_daily_auto_config"
 CREATE INDEX "IDX_voice_daily_channel_type"
   ON voice_daily ("guildId", "date")
   WHERE "channelType" != 'permanent';
+
+-- 자동방 button 단위 그룹핑 조회 최적화 (partial index)
+CREATE INDEX "IDX_voice_daily_auto_button"
+  ON voice_daily ("guildId", "autoChannelButtonId", "date")
+  WHERE "autoChannelButtonId" IS NOT NULL;
 ```
 
-기존 레코드의 `channelType`은 기본값 `'permanent'`로 유지되어 하위 호환이 보장된다. `autoChannelConfigId` / `autoChannelConfigName`은 NULL로 유지된다.
+기존 레코드의 `channelType`은 기본값 `'permanent'`로 유지되어 하위 호환이 보장된다. 나머지 네 컬럼(`autoChannelConfigId`, `autoChannelConfigName`, `autoChannelButtonId`, `autoChannelButtonLabel`)은 NULL로 초기화된다. `auto_instant` 모드 레코드의 `autoChannelButtonId` / `autoChannelButtonLabel`도 항상 NULL이다.
 
 #### 인덱스
 
@@ -596,6 +606,7 @@ CREATE INDEX "IDX_voice_daily_channel_type"
 | `IDX_voice_daily_guild_user_date` | `(guildId, userId, date)` | 유저별 조회 (F-VOICE-018 userId 필터) |
 | `IDX_voice_daily_auto_config` | `(guildId, autoChannelConfigId, date)` WHERE `autoChannelConfigId IS NOT NULL` | 자동방 config 단위 그룹핑 조회 최적화 (F-VOICE-032~035) |
 | `IDX_voice_daily_channel_type` | `(guildId, date)` WHERE `channelType != 'permanent'` | 자동방 채널 필터링 최적화 (F-VOICE-036~039). permanent가 다수이므로 partial index |
+| `IDX_voice_daily_auto_button` | `(guildId, autoChannelButtonId, date)` WHERE `autoChannelButtonId IS NOT NULL` | 자동방 button 단위 그룹핑 조회 최적화 (F-VOICE-032~038). `auto_instant` 모드는 null이므로 partial index |
 
 #### F-VOICE-019 멤버 검색 인덱스 검토
 

--- a/docs/specs/prd/voice.md
+++ b/docs/specs/prd/voice.md
@@ -1087,23 +1087,35 @@ flush 시점에 `channelId`만으로는 해당 채널이 자동방인지, 어떤
 - **동작**:
   1. 확정방 생성이 완료되는 세 지점 각각에서 `VoiceRedisRepository.setAutoChannelInfo()` 호출
   2. `voice:channel:auto:{guildId}:{channelId}` 키에 자동방 메타데이터를 7일 TTL로 저장
-  3. 저장 값: `{ configId: number, configName: string, channelType: 'auto_select' | 'auto_instant' }`
+  3. 저장 값: `{ configId: number, configName: string, channelType: 'auto_select' | 'auto_instant', buttonId: number | null, buttonLabel: string | null }`
+     - **선택 생성 모드** (2지점): `buttonId = button.id`, `buttonLabel = button.label`
+     - **즉시 생성 모드** (1지점): `buttonId = null`, `buttonLabel = null` (버튼 없음)
   4. 채널 삭제 이후에도 TTL이 만료되기 전까지 flush 시점에서 조회 가능
+- **AutoChannelInfo 인터페이스**:
+
+  | 필드 | 타입 | null 허용 | 설명 |
+  |------|------|-----------|------|
+  | `configId` | `number` | 불가 | AutoChannelConfig PK |
+  | `configName` | `string` | 불가 | Config 이름 스냅샷 |
+  | `channelType` | `'auto_select' \| 'auto_instant'` | 불가 | 자동방 생성 모드 |
+  | `buttonId` | `number` | 허용 | AutoChannelButton PK. 즉시 모드는 null |
+  | `buttonLabel` | `string` | 허용 | 버튼 라벨 스냅샷. 즉시 모드는 null |
+
 - **새 Redis 키**:
 
   | 키 패턴 | 값 | TTL | 설명 |
   |---------|-----|-----|------|
-  | `voice:channel:auto:{guildId}:{channelId}` | `{ configId, configName, channelType }` | 7일 | 확정방의 auto-channel 메타데이터 캐시 |
+  | `voice:channel:auto:{guildId}:{channelId}` | `{ configId, configName, channelType, buttonId, buttonLabel }` | 7일 | 확정방의 auto-channel 메타데이터 캐시 |
 
 - **관련 파일**:
   - `apps/api/src/channel/voice/infrastructure/voice-cache.keys.ts` — `autoChannelInfo(guild, channel)` 키 추가
-  - `apps/api/src/channel/voice/infrastructure/voice-redis.repository.ts` — `setAutoChannelInfo()` / `getAutoChannelInfo()` 메서드 추가
-  - `apps/api/src/channel/auto/application/auto-channel.service.ts` — 확정방 생성 3지점에 `setAutoChannelInfo()` 호출 추가
+  - `apps/api/src/channel/voice/infrastructure/voice-redis.repository.ts` — `setAutoChannelInfo()` / `getAutoChannelInfo()` 메서드 추가 (반환 타입에 `buttonId`, `buttonLabel` 포함)
+  - `apps/api/src/channel/auto/application/auto-channel.service.ts` — 선택 모드 2지점에 `button.id` / `button.label` 추가 전달, 즉시 모드 1지점에 `buttonId: null` / `buttonLabel: null` 전달
   - `apps/api/src/channel/auto/auto-channel.module.ts` — `VoiceRedisRepository` provider 공유 설정
 
 ### F-VOICE-033: voice_daily 테이블 채널 유형 컬럼 추가
 
-- **배경**: `voice_daily` 레코드에 채널 유형 정보를 영구 저장하여, 이후 통계 조회 시 필터링 및 그룹핑을 지원한다.
+- **배경**: `voice_daily` 레코드에 채널 유형 정보 및 버튼 단위 메타데이터를 영구 저장하여, 이후 통계 조회 시 버튼별 필터링 및 그룹핑을 지원한다.
 - **동작**: 마이그레이션을 통해 다음 컬럼을 `voice_daily` 테이블에 추가한다.
 - **VoiceDailyEntity (voice_daily) — 추가 컬럼**:
 
@@ -1112,16 +1124,20 @@ flush 시점에 `channelId`만으로는 해당 채널이 자동방인지, 어떤
   | `channelType` | varchar(20) | `'permanent'` | 불가 | 채널 유형. `'permanent'` \| `'auto_select'` \| `'auto_instant'` |
   | `autoChannelConfigId` | int | — | 허용 | `auto_channel_config.id` 논리 참조 (FK 제약 없음 — config 삭제 후에도 통계 유지) |
   | `autoChannelConfigName` | varchar(255) | — | 허용 | config.name 스냅샷 (config 삭제 후에도 표시명 유지) |
+  | `autoChannelButtonId` | int | — | 허용 | `auto_channel_button.id` 논리 참조 (FK 제약 없음). 즉시 모드는 null |
+  | `autoChannelButtonLabel` | varchar(255) | — | 허용 | 버튼 라벨 스냅샷. 즉시 모드는 null |
 
 - **기존 데이터 처리**:
   - `channelType` 기본값 `'permanent'`으로 기존 레코드와 호환 유지
-  - `autoChannelConfigId`, `autoChannelConfigName`은 null로 초기화
+  - `autoChannelConfigId`, `autoChannelConfigName`, `autoChannelButtonId`, `autoChannelButtonLabel`은 null로 초기화
 - **마이그레이션 SQL**:
   ```sql
   ALTER TABLE voice_daily
     ADD COLUMN "channelType" VARCHAR(20) NOT NULL DEFAULT 'permanent',
     ADD COLUMN "autoChannelConfigId" INTEGER NULL,
-    ADD COLUMN "autoChannelConfigName" VARCHAR(255) NULL;
+    ADD COLUMN "autoChannelConfigName" VARCHAR(255) NULL,
+    ADD COLUMN "autoChannelButtonId" INTEGER NULL,
+    ADD COLUMN "autoChannelButtonLabel" VARCHAR(255) NULL;
   ```
 - **추가 인덱스**:
   ```sql
@@ -1130,35 +1146,40 @@ flush 시점에 `channelId`만으로는 해당 채널이 자동방인지, 어떤
     ON voice_daily ("guildId", "autoChannelConfigId", "date")
     WHERE "autoChannelConfigId" IS NOT NULL;
 
+  -- 자동방 button 단위 그룹핑 조회 최적화
+  CREATE INDEX "IDX_voice_daily_auto_button"
+    ON voice_daily ("guildId", "autoChannelButtonId", "date")
+    WHERE "autoChannelButtonId" IS NOT NULL;
+
   -- channelType 필터링 최적화
   CREATE INDEX "IDX_voice_daily_channel_type"
     ON voice_daily ("guildId", "channelType", "date");
   ```
 - **관련 파일**:
-  - `apps/api/src/channel/voice/infrastructure/voice-daily.orm-entity.ts` — 컬럼 3개 추가
-  - `apps/api/src/migrations/1776400000000-AddAutoChannelGrouping.ts` — 신규 마이그레이션
+  - `apps/api/src/channel/voice/infrastructure/voice-daily.orm-entity.ts` — 컬럼 5개 추가
+  - `apps/api/src/migrations/1776400000000-AddAutoChannelGrouping.ts` — 신규 마이그레이션 (버튼 컬럼 2개 포함)
 
 ### F-VOICE-034: Flush 로직 auto-channel 메타데이터 주입
 
 - **트리거**: `VoiceDailyFlushService.flushDate()` 실행 시 (세션 종료 또는 날짜 변경 flush, `safeFlushAll()`)
 - **동작**:
   1. `flushDate()` 내부 채널별 루프에서 `channelId`로 `VoiceRedisRepository.getAutoChannelInfo(guildId, channelId)` 조회
-  2. 조회 결과를 `accumulateChannelDuration()` 호출 시 추가 파라미터로 전달
-  3. auto-channel 정보가 없으면 `channelType = 'permanent'`, `autoChannelConfigId = null`, `autoChannelConfigName = null` 적용
-  4. `accumulateChannelDuration()` UPSERT SQL에서 새 세 컬럼을 포함하여 저장 (`COALESCE`로 기존 값 우선 보존)
+  2. 조회 결과에서 `configId`, `configName`, `channelType`, `buttonId`, `buttonLabel`을 추출하여 `accumulateChannelDuration()` 호출 시 추가 파라미터로 전달
+  3. auto-channel 정보가 없으면 `channelType = 'permanent'`, `autoChannelConfigId = null`, `autoChannelConfigName = null`, `autoChannelButtonId = null`, `autoChannelButtonLabel = null` 적용
+  4. `accumulateChannelDuration()` UPSERT SQL에서 새 다섯 컬럼을 포함하여 저장 (`COALESCE`로 기존 값 우선 보존)
 - **하위 호환**:
   - F-VOICE-032(Redis 분리 저장) 이전에 생성된 확정방은 메타데이터 조회 결과가 null이므로 기존 동작(`permanent`)을 유지
 - **관련 파일**:
-  - `apps/api/src/channel/voice/application/voice-daily-flush-service.ts` — `flushDate()` 확장
-  - `apps/api/src/channel/voice/infrastructure/voice-daily.repository.ts` — `accumulateChannelDuration()` 시그니처 및 UPSERT SQL 확장
+  - `apps/api/src/channel/voice/application/voice-daily-flush-service.ts` — `flushDate()` 확장 (`buttonId`, `buttonLabel` 추출 포함)
+  - `apps/api/src/channel/voice/infrastructure/voice-daily.repository.ts` — `accumulateChannelDuration()` 시그니처 및 UPSERT SQL 확장 (버튼 컬럼 2개 추가)
 
 ### F-VOICE-035: VoiceDailyRecord DTO 및 API 응답 확장
 
 - **배경**: 기존 클라이언트 호환성을 유지하면서, 새 필드를 옵셔널로 추가한다.
 - **동작**:
-  1. `VoiceDailyRecordDto`에 `channelType`, `autoChannelConfigId`, `autoChannelConfigName` 필드 추가
-  2. `VoiceDailyService`의 엔티티 → DTO 매핑에 세 필드 포함
-  3. `ChannelStatItem`(libs/shared)에 세 필드 추가
+  1. `VoiceDailyRecordDto`에 `channelType`, `autoChannelConfigId`, `autoChannelConfigName`, `autoChannelButtonId`, `autoChannelButtonLabel` 필드 추가
+  2. `VoiceDailyService`의 엔티티 → DTO 매핑에 다섯 필드 포함
+  3. `ChannelStatItem`(libs/shared)에 다섯 필드 추가
   4. `VoiceAnalyticsService.getChannelStats()`에서 새 필드 매핑 적용
 - **VoiceDailyRecordDto 변경 필드**:
 
@@ -1167,6 +1188,8 @@ flush 시점에 `channelId`만으로는 해당 채널이 자동방인지, 어떤
   | `channelType` | `'permanent' \| 'auto_select' \| 'auto_instant'` | 채널 유형. 기존 레코드는 `'permanent'` |
   | `autoChannelConfigId` | `number \| null` | auto-channel config 내부 ID |
   | `autoChannelConfigName` | `string \| null` | config 이름 스냅샷 |
+  | `autoChannelButtonId` | `number \| null` | auto-channel button 내부 ID. 즉시 모드는 null |
+  | `autoChannelButtonLabel` | `string \| null` | 버튼 라벨 스냅샷. 즉시 모드는 null |
 
 - **API 응답 예시** (F-VOICE-017 / F-VOICE-018 응답 스키마 확장):
   ```json
@@ -1179,6 +1202,8 @@ flush 시점에 `channelId`만으로는 해당 채널이 자동방인지, 어떤
     "channelType": "auto_select",
     "autoChannelConfigId": 7,
     "autoChannelConfigName": "게임방",
+    "autoChannelButtonId": 42,
+    "autoChannelButtonLabel": "일반방",
     "channelDurationSec": 5400
   }
   ```
@@ -1186,7 +1211,7 @@ flush 시점에 `channelId`만으로는 해당 채널이 자동방인지, 어떤
 - **관련 파일**:
   - `apps/api/src/channel/voice/dto/voice-daily-record.dto.ts`
   - `apps/api/src/channel/voice/application/voice-daily.service.ts`
-  - `libs/shared/src/types/diagnosis.ts` — `ChannelStatItem` 확장
+  - `libs/shared/src/types/diagnosis.ts` — `ChannelStatItem` 확장 (버튼 필드 2개 추가)
   - `apps/api/src/voice-analytics/application/voice-analytics.service.ts`
 
 ### F-VOICE-036: VoiceAnalyticsService 자동방 그룹핑 API 지원
@@ -1194,40 +1219,44 @@ flush 시점에 `channelId`만으로는 해당 채널이 자동방인지, 어떤
 - **배경**: 서버사이드 분석 API에서도 자동방 그룹핑을 지원하여, 클라이언트가 서버에 집계를 위임할 수 있도록 한다.
 - **엔드포인트 변경**: `GET /api/guilds/:guildId/voice-analytics/channel-stats`
   - 기존 쿼리 파라미터 유지 + `groupAutoChannels` 추가
-  - `groupAutoChannels=true`인 경우: `autoChannelConfigId`가 같은 레코드를 합산하고, `channelId`를 `auto:{configId}`, `channelName`을 `configName`으로 치환
+  - `groupAutoChannels=true`인 경우:
+    - `autoChannelButtonId`가 있는 레코드는 `buttonId` 기준으로 그룹핑하고, `channelId`를 `auto:btn:{buttonId}`, `channelName`을 `buttonLabel`로 치환
+    - `autoChannelButtonId`가 null(즉시 모드)인 레코드는 `autoChannelConfigId` 기준으로 폴백 그룹핑하고, `channelId`를 `auto:{configId}`, `channelName`을 `configName`으로 치환
 - **쿼리 파라미터 추가**:
 
   | 파라미터 | 타입 | 기본값 | 설명 |
   |----------|------|--------|------|
-  | `groupAutoChannels` | boolean | `false` | `true`이면 자동방을 config 단위로 그룹핑하여 집계 |
+  | `groupAutoChannels` | boolean | `false` | `true`이면 자동방을 button 단위(즉시 모드는 config 단위 폴백)로 그룹핑하여 집계 |
 
 - **관련 파일**:
-  - `apps/api/src/voice-analytics/application/voice-analytics.service.ts` — `getChannelStats()` 그룹핑 로직 추가
+  - `apps/api/src/voice-analytics/application/voice-analytics.service.ts` — `getChannelStats()` 그룹핑 로직 변경 (키를 `buttonId` 우선, `configId` 폴백으로 교체)
   - `apps/api/src/voice-analytics/presentation/diagnosis.controller.ts` — `groupAutoChannels` 파라미터 추가
   - `apps/api/src/voice-analytics/presentation/dto/diagnosis-query.dto.ts` — `groupAutoChannels` 필드 추가
 
 ### F-VOICE-037: 프론트엔드 타입 확장 및 자동방 그룹 집계 함수
 
-- **배경**: 대시보드 클라이언트에서 자동방 통계를 config 단위로 집계하고 필터링한다.
+- **배경**: 대시보드 클라이언트에서 자동방 통계를 button 단위로 집계하고 필터링한다.
 - **동작**:
-  1. `VoiceDailyRecord` 타입에 `channelType`, `autoChannelConfigId`, `autoChannelConfigName` 필드 추가
-  2. `VoiceAutoChannelGroupStat` 인터페이스 신규 추가 (config 단위 그룹 통계)
-  3. `computeAutoChannelGroupStats(records)` 함수 추가: `autoChannelConfigId`가 같은 레코드를 합산하여 config 단위 통계를 반환
+  1. `VoiceDailyRecord` 타입에 `channelType`, `autoChannelConfigId`, `autoChannelConfigName`, `autoChannelButtonId`, `autoChannelButtonLabel` 필드 추가
+  2. `VoiceAutoChannelGroupStat` 인터페이스 신규 추가 (button 단위 그룹 통계)
+  3. `computeAutoChannelGroupStats(records)` 함수 추가: 그룹 키를 `buttonId ?? configId`로 사용하여 button 단위(즉시 모드는 config 단위 폴백)로 합산하여 통계를 반환
   4. `computeChannelStats(records, groupMode)` 함수에 `groupMode` 옵션 추가:
      - `'individual'` (기본): 기존 동작 (하위 호환)
-     - `'auto_grouped'`: `autoChannelConfigId`가 같은 레코드를 합산하고, 상설 채널은 그대로 유지
+     - `'auto_grouped'`: 그룹 키를 `buttonId ?? configId`로 사용하여 자동방을 합산하고, 상설 채널은 그대로 유지
 - **VoiceAutoChannelGroupStat 인터페이스**:
 
   | 필드 | 타입 | 설명 |
   |------|------|------|
   | `autoChannelConfigId` | `number` | config 내부 ID |
   | `autoChannelConfigName` | `string` | config 이름 |
+  | `autoChannelButtonId` | `number \| null` | button 내부 ID. 즉시 모드는 null |
+  | `autoChannelButtonLabel` | `string \| null` | 버튼 라벨 스냅샷. 즉시 모드는 null |
   | `channelType` | `'auto_select' \| 'auto_instant'` | 자동방 유형 |
-  | `totalDurationSec` | `number` | 해당 config 소속 채널들의 총 체류 시간(초) |
-  | `instanceCount` | `number` | 해당 config로 생성된 고유 채널 수 |
+  | `totalDurationSec` | `number` | 해당 그룹 소속 채널들의 총 체류 시간(초) |
+  | `instanceCount` | `number` | 해당 그룹으로 생성된 고유 채널 수 |
 
 - **관련 파일**:
-  - `apps/web/app/lib/voice-dashboard-api.ts` — 타입 확장, `computeAutoChannelGroupStats()` 추가, `computeChannelStats()` 그룹핑 옵션 추가
+  - `apps/web/app/lib/voice-dashboard-api.ts` — 타입 확장 (버튼 필드 2개 추가), `computeAutoChannelGroupStats()` 그룹 키 변경 (`buttonId ?? configId`), `computeChannelStats()` 그룹핑 키 동일하게 변경
 
 ### F-VOICE-038: 대시보드 UI — 채널 유형 필터 및 자동방 그룹 탭
 
@@ -1238,19 +1267,19 @@ flush 시점에 `channelId`만으로는 해당 채널이 자동방인지, 어떤
   - 기존 탭 (채널 | 카테고리) 에 "자동방 그룹" 탭 추가
   - "채널" 탭: 기존 동작 (개별 channelId 기준) 유지
   - "카테고리" 탭: 기존 동작 유지
-  - "자동방 그룹" 탭 (신규): `computeAutoChannelGroupStats()`를 사용하여 `autoChannelConfigId` 기준 그룹핑된 막대 차트 표시
+  - "자동방 그룹" 탭 (신규): `computeAutoChannelGroupStats()`를 사용하여 button 단위(즉시 모드는 config 단위 폴백)로 그룹핑된 막대 차트 표시. 표시명은 `autoChannelButtonLabel` 우선, 없으면 `autoChannelConfigName` 폴백
   - 채널 유형 필터 드롭다운 추가 (전체 | 상설 채널 | 자동방):
     - "전체": 모든 `channelType` 포함
     - "상설 채널": `channelType === 'permanent'`만 표시
     - "자동방": `channelType !== 'permanent'`만 표시
 
   **SummaryCards**:
-  - `uniqueChannels` 계산 시 자동방을 config 단위로 카운트하는 옵션 적용
+  - `uniqueChannels` 계산 시 자동방을 button 단위로 카운트하는 옵션 적용
   - 변경 전: `new Set(records.map(r => r.channelId)).size`
-  - 변경 후: 상설 채널 수 + 자동방 config 수 (중복 제거)
+  - 변경 후: 상설 채널 수 + 자동방 고유 그룹 수 (`buttonId ?? configId` 기준 중복 제거)
 
   **UserChannelPieChart**:
-  - 자동방 그룹핑 모드 적용 — `computeChannelStats(records, 'auto_grouped')` 사용하여 config 단위로 파이 슬라이스 표시
+  - 자동방 그룹핑 모드 적용 — `computeChannelStats(records, 'auto_grouped')` 사용하여 button 단위(즉시 모드는 config 단위 폴백)로 파이 슬라이스 표시
 
 - **i18n 추가 키**:
 
@@ -1261,7 +1290,7 @@ flush 시점에 `channelId`만으로는 해당 채널이 자동방인지, 어떤
   | `voice.channelChart.filterPermanent` | 상설 채널 | Permanent |
   | `voice.channelChart.filterAuto` | 자동방 | Auto Channel |
   | `voice.channelChart.instanceCount` | 생성된 방 수 | Instances |
-  | `voice.summary.autoChannelGroups` | 자동방 설정 | Auto Channel Configs |
+  | `voice.summary.autoChannelGroups` | 자동방 버튼 | Auto Channel Buttons |
 
 - **관련 파일**:
   - `apps/web/app/dashboard/guild/[guildId]/voice/components/ChannelBarChart.tsx`
@@ -1283,3 +1312,106 @@ flush 시점에 `channelId`만으로는 해당 채널이 자동방인지, 어떤
   - 실행 전 `SELECT COUNT(*)` 으로 영향 범위를 확인한 후 적용할 것
   - 필요 시 채널명 패턴 매칭 등 추가 필터를 적용하여 정확도를 높임
 - **관련 파일**: 일회성 SQL 스크립트 (별도 파일로 관리, 마이그레이션에 포함하지 않음)
+
+---
+
+## 서버 진단 API (Voice Analytics)
+
+> 변경이력: [prd-changelog.md](../../archive/prd-changelog.md)
+
+### 개요
+
+`VoiceAnalyticsService` 및 `VoiceAiAnalysisService`가 제공하는 서버 건강도 점수 계산, 유저 리더보드 조회, AI 진단 텍스트 생성 기능의 백엔드 명세이다. 프론트엔드 서버 진단 대시보드(`F-WEB-016`)에서 호출한다.
+
+### F-VOICE-040: 서버 건강도 점수 산출 API
+
+- **엔드포인트**: `GET /api/guilds/:guildId/voice-analytics/health-score?days=N`
+- **인증**: JWT Bearer 토큰 필수
+- **동작**:
+  1. 대상 기간(`days`)과 직전 동일 기간의 `voice_daily` 레코드를 각각 조회한다.
+  2. 각 기간에 대해 `calculateHealthScore(totalStats, dailyTrends, days)`를 호출하여 0~100 점수를 산출한다.
+  3. LLM을 호출하지 않고 DB 쿼리만 수행하여 ~500ms 이내 응답을 보장한다.
+  4. 응답의 `diagnosis` 필드는 빈 문자열(`""`)로 반환하며, 실제 AI 진단 텍스트는 `F-VOICE-041` 별도 엔드포인트를 통해 비동기 조회한다.
+- **건강도 점수 산출 공식** (`calculateHealthScore`):
+  - 정규화 함수: `normalize(value, midpoint) = 100 × value / (value + midpoint)` (로그 커브)
+  - 지표별 가중 합산:
+
+    | 지표 | 가중치 | midpoint | 설명 |
+    |------|--------|----------|------|
+    | 일평균 활성 유저 수 | 40% | 10명 | `totalStats.avgDailyActiveUsers` |
+    | 일평균 총 음성 시간 | 30% | 5시간 | `totalStats.totalVoiceTime / 3600 / days` |
+    | 마이크 사용률 | 20% | 30% | `totalMicOnTime / totalVoiceTime × 100` |
+    | 활동일 비율 | 10% | 50% | `dailyTrends.length / days × 100` |
+
+  - 최종 점수: `Math.min(100, Math.round(가중합산))`
+  - `dailyTrends` 파라미터는 활동일 비율 계산을 위해 `calculateHealthScore()` 시그니처에 추가됨
+  - **개선 이전 공식** (참고용): `min(100, avgDailyActiveUsers × 10 + dailyAvgHours × 5)` — 일평균 10명만 넘으면 무조건 100점이 되는 문제가 있어 폐기
+- **응답 형식**:
+  ```json
+  {
+    "score": 72,
+    "prevScore": 65,
+    "delta": 7,
+    "diagnosis": ""
+  }
+  ```
+- **관련 파일**:
+  - `apps/api/src/voice-analytics/application/voice-analytics.service.ts` — `calculateHealthScore()` (private), `getHealthScore()` 메서드
+
+### F-VOICE-041: 서버 건강도 AI 진단 텍스트 조회 API
+
+- **엔드포인트**: `GET /api/guilds/:guildId/voice-analytics/health-diagnosis?days=N`
+- **인증**: JWT Bearer 토큰 필수
+- **동작**:
+  1. `VoiceAiAnalysisService.generateHealthDiagnosis()`를 호출하여 LLM 기반 진단 텍스트를 생성한다.
+  2. 캐시 TTL: 30분 (Redis). 동일 guildId + days 조합은 캐시 히트 시 LLM 호출 없이 즉시 반환.
+  3. LLM 출력 토큰 한도: `maxOutputTokens: 1024`. 한국어는 영어 대비 토큰 소모가 높아 512 토큰으로는 2~3문장 완성 전에 응답이 잘리는 문제가 있어 1024로 상향 조정.
+- **응답 형식**:
+  ```json
+  {
+    "diagnosis": "이번 기간 서버의 음성 활동은 전반적으로 활발한 편입니다. ..."
+  }
+  ```
+- **관련 파일**:
+  - `apps/api/src/voice-analytics/application/voice-ai-analysis.service.ts` — `generateHealthDiagnosis()` (`maxOutputTokens: 1024`)
+
+### F-VOICE-042: 유저 리더보드 조회 API
+
+- **엔드포인트**: `GET /api/guilds/:guildId/voice-analytics/leaderboard?days=N&page=P&limit=L`
+- **인증**: JWT Bearer 토큰 필수
+- **쿼리 파라미터**:
+
+  | 파라미터 | 타입 | 기본값 | 설명 |
+  |----------|------|--------|------|
+  | `days` | number | 30 | 조회 기간(일) |
+  | `page` | number | 1 | 페이지 번호 (1-based) |
+  | `limit` | number | 10 | 페이지당 항목 수 |
+
+- **동작**:
+  1. 대상 기간의 `voice_daily` 레코드를 전체 조회하여 유저별 총 음성시간·마이크 ON 시간·활동일 수를 집계한다.
+  2. 총 음성시간 기준 내림차순 정렬 후 페이지네이션을 적용한다.
+  3. 페이징된 유저 ID 목록에 대해 `GuildMemberService.findByUserIds(guildId, pagedUserIds)`를 호출하여 실제 아바타 URL을 조회한 뒤 응답에 포함한다.
+     - 아바타 URL을 페이징된 유저에 한해서만 조회하여 불필요한 전체 조회를 방지한다.
+     - `GuildMemberService`에 해당 유저의 길드 멤버 레코드가 없으면 `avatarUrl: null`을 반환한다.
+  4. **아바타 조회 이전 동작** (참고용): `avatarUrl: null` 하드코딩으로 항상 null을 반환하여 프론트엔드의 이니셜 폴백만 표시되던 문제가 있었음.
+- **응답 형식**:
+  ```json
+  {
+    "users": [
+      {
+        "rank": 1,
+        "userId": "111111111111111111",
+        "nickName": "Onyu",
+        "avatarUrl": "https://cdn.discordapp.com/avatars/111.../abc.webp?size=128",
+        "totalSec": 86400,
+        "micOnSec": 43200,
+        "activeDays": 14
+      }
+    ],
+    "total": 42
+  }
+  ```
+  - `avatarUrl`: Discord CDN URL. `GuildMemberService`에 멤버 레코드가 없으면 `null`
+- **관련 파일**:
+  - `apps/api/src/voice-analytics/application/voice-analytics.service.ts` — `getLeaderboard()` 메서드
+  - `apps/api/src/guild-member/application/guild-member.service.ts` — `findByUserIds()`

--- a/libs/i18n/locales/en/web/dashboard.json
+++ b/libs/i18n/locales/en/web/dashboard.json
@@ -68,7 +68,7 @@
       "alone": "Alone Time",
       "activeUsers": "Active Users",
       "usedChannels": "Channels Used",
-      "autoChannelGroups": "Auto Configs"
+      "autoChannelGroups": "Auto Channel Buttons"
     },
     "dailyTrend": {
       "title": "Daily Voice Activity Trend",

--- a/libs/i18n/locales/ko/web/dashboard.json
+++ b/libs/i18n/locales/ko/web/dashboard.json
@@ -68,7 +68,7 @@
       "alone": "혼자 있는 시간",
       "activeUsers": "활성 유저",
       "usedChannels": "사용 채널",
-      "autoChannelGroups": "자동방 설정"
+      "autoChannelGroups": "자동방 버튼"
     },
     "dailyTrend": {
       "title": "일별 음성 활동 추이",

--- a/libs/shared/src/types/diagnosis.ts
+++ b/libs/shared/src/types/diagnosis.ts
@@ -44,6 +44,8 @@ export interface ChannelStatItem {
   channelType: 'permanent' | 'auto_select' | 'auto_instant';
   autoChannelConfigId: number | null;
   autoChannelConfigName: string | null;
+  autoChannelButtonId: number | null;
+  autoChannelButtonLabel: string | null;
 }
 
 export interface ChannelStatsResponse {


### PR DESCRIPTION
## Summary
- 자동방 버튼 그룹핑 백엔드/프론트엔드 구현
- 서버진단 리더보드 아바타 미노출 수정
- 서버진단 건강도 점수 공식 로그 커브 기반 개선 (항상 100점 문제 해결)
- 서버진단 건강도 LLM 진단 텍스트 잘림 수정 (maxOutputTokens 512→1024)
- 뉴비·모코·오버뷰 테스트 업데이트
- PRD 및 계획 문서 업데이트

## Test plan
- [x] 전체 테스트 통과 (881 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)