### PR TITLE
fix: LavaSrc 4.8.1 → 4.3.0 다운그레이드

### DIFF
--- a/lavalink/application.yml
+++ b/lavalink/application.yml
@@ -4,7 +4,7 @@ server:
 
 lavalink:
   plugins:
-    - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.8.1"
+    - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.3.0"
       snapshot: false
   server:
     password: "youshallnotpass"
@@ -27,19 +27,11 @@ plugins:
       deezer: true
       applemusic: false
       yandexmusic: false
-      flowerytts: false
-      youtube: false
-      vkmusic: false
-      tidal: false
-      qobuz: false
-      ytdlp: false
-      jiosaavn: false
     spotify:
       clientId: "${SPOTIFY_CLIENT_ID}"
       clientSecret: "${SPOTIFY_CLIENT_SECRET}"
       countryCode: "KR"
     deezer:
-      masterDecryptionKey: "${DEEZER_MASTER_KEY}"
       countryCode: "KR"
 
 logging:


### PR DESCRIPTION
## Summary
- LavaSrc 4.8.1은 Deezer `arl` + `masterDecryptionKey` 필수 → 무료 스트리밍 불가
- 4.3.0으로 다운그레이드하여 인증 없이 128kbps 스트리밍 가능
- 4.8.1 전용 소스 옵션 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)