### PR TITLE
fix: Deezer masterDecryptionKey 설정 복원

### DIFF
--- a/lavalink/application.yml
+++ b/lavalink/application.yml
@@ -32,6 +32,7 @@ plugins:
       clientSecret: "${SPOTIFY_CLIENT_SECRET}"
       countryCode: "KR"
     deezer:
+      masterDecryptionKey: "${DEEZER_MASTER_KEY}"
       countryCode: "KR"
 
 logging:


### PR DESCRIPTION
LavaSrc 4.3.0에서도 masterDecryptionKey 필수. 환경변수 참조 복원.