### PR TITLE
fix: Spotify 검색 403 → Deezer 직접 검색으로 전환

### DIFF
--- a/apps/bot/src/music/infrastructure/kazagumo.provider.ts
+++ b/apps/bot/src/music/infrastructure/kazagumo.provider.ts
@@ -25,8 +25,8 @@ export class KazagumoProvider implements OnModuleInit, OnApplicationShutdown {
 
     this.kazagumo = new Kazagumo(
       {
-        defaultSearchEngine: 'spotify',
-        defaultSource: 'spsearch:',
+        defaultSearchEngine: 'youtube',
+        defaultSource: 'dzsearch:',
         plugins: [],
         send: (guildId, payload) => {
           const guild = this.client.guilds.cache.get(guildId);


### PR DESCRIPTION
LavaSrc 4.3.0 Spotify 검색 API 403 에러 → dzsearch: prefix로 Deezer 직접 검색 전환