### PR TITLE
fix: Spotify 소스 비활성화 (프리미엄 구독 필수)

### DIFF
--- a/lavalink/application.yml
+++ b/lavalink/application.yml
@@ -23,7 +23,7 @@ plugins:
       - "dzisrc:%ISRC%"
       - "dzsearch:%QUERY%"
     sources:
-      spotify: true
+      spotify: false
       deezer: true
       applemusic: false
       yandexmusic: false


### PR DESCRIPTION
Spotify API 403: 프리미엄 필수. Deezer 직접 검색만 사용하므로 spotify source false 처리.