### PR TITLE
fix: YouTube OAuth 복원, Deezer/Spotify/LavaSrc 제거

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,12 +33,8 @@ WEB_URL=http://localhost:4000
 LAVALINK_URL=lavalink:2333
 LAVALINK_PASSWORD=youshallnotpass
 
-# Spotify (required, for Lavalink LavaSrc plugin - Spotify search + Deezer streaming)
-SPOTIFY_CLIENT_ID=
-SPOTIFY_CLIENT_SECRET=
-
-# Deezer (required, master decryption key for Deezer streaming)
-DEEZER_MASTER_KEY=
+# YouTube OAuth (optional, refresh token for YouTube plugin authentication)
+YOUTUBE_OAUTH_REFRESH_TOKEN=
 
 # ─── Monitoring ──────────────────────────────────────────
 # Grafana admin 계정

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -56,12 +56,10 @@ GEMINI_API_KEY=your_gemini_api_key
 LAVALINK_URL=lavalink:2333
 LAVALINK_PASSWORD=youshallnotpass
 
-# ─── Spotify (필수, Spotify 검색 + Deezer 스트리밍) ──────
-SPOTIFY_CLIENT_ID=your_spotify_client_id
-SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
-
-# ─── Deezer (필수, 스트리밍 복호화 키) ───────────────────
-DEEZER_MASTER_KEY=your_deezer_master_key
+# ─── YouTube OAuth (음악 재생 인증) ─────────────────────
+# Lavalink 최초 기동 시 로그에서 device code 확인 후 인증
+# 인증 완료 후 refresh token이 자동 저장됨
+YOUTUBE_OAUTH_REFRESH_TOKEN=
 
 # ─── Monitoring ──────────────────────────────────────────
 # Grafana admin 계정 (프로덕션에서는 반드시 변경)

--- a/apps/bot/src/music/infrastructure/kazagumo.provider.ts
+++ b/apps/bot/src/music/infrastructure/kazagumo.provider.ts
@@ -26,7 +26,6 @@ export class KazagumoProvider implements OnModuleInit, OnApplicationShutdown {
     this.kazagumo = new Kazagumo(
       {
         defaultSearchEngine: 'youtube',
-        defaultSource: 'dzsearch:',
         plugins: [],
         send: (guildId, payload) => {
           const guild = this.client.guilds.cache.get(guildId);

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -75,9 +75,7 @@ services:
       - ./lavalink/application.yml:/opt/Lavalink/application.yml
     environment:
       - _JAVA_OPTIONS=-Xmx128m
-      - SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID:-}
-      - SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET:-}
-      - DEEZER_MASTER_KEY=${DEEZER_MASTER_KEY:-}
+      - YOUTUBE_OAUTH_REFRESH_TOKEN=${YOUTUBE_OAUTH_REFRESH_TOKEN:-}
     restart: unless-stopped
 
   db:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,9 +53,7 @@ services:
       - ./lavalink/application.yml:/opt/Lavalink/application.yml
     environment:
       - _JAVA_OPTIONS=-Xmx128m
-      - SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID:-}
-      - SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET:-}
-      - DEEZER_MASTER_KEY=${DEEZER_MASTER_KEY:-}
+      - YOUTUBE_OAUTH_REFRESH_TOKEN=${YOUTUBE_OAUTH_REFRESH_TOKEN:-}
     restart: unless-stopped
 
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,9 +72,7 @@ services:
       - ./lavalink/application.yml:/opt/Lavalink/application.yml
     environment:
       - _JAVA_OPTIONS=-Xmx128m
-      - SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID:-}
-      - SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET:-}
-      - DEEZER_MASTER_KEY=${DEEZER_MASTER_KEY:-}
+      - YOUTUBE_OAUTH_REFRESH_TOKEN=${YOUTUBE_OAUTH_REFRESH_TOKEN:-}
     restart: unless-stopped
 
   db:

--- a/lavalink/application.yml
+++ b/lavalink/application.yml
@@ -4,7 +4,7 @@ server:
 
 lavalink:
   plugins:
-    - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.3.0"
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.18.0"
       snapshot: false
   server:
     password: "youshallnotpass"
@@ -18,22 +18,19 @@ lavalink:
       local: false
 
 plugins:
-  lavasrc:
-    providers:
-      - "dzisrc:%ISRC%"
-      - "dzsearch:%QUERY%"
-    sources:
-      spotify: false
-      deezer: true
-      applemusic: false
-      yandexmusic: false
-    spotify:
-      clientId: "${SPOTIFY_CLIENT_ID}"
-      clientSecret: "${SPOTIFY_CLIENT_SECRET}"
-      countryCode: "KR"
-    deezer:
-      masterDecryptionKey: "${DEEZER_MASTER_KEY}"
-      countryCode: "KR"
+  youtube:
+    enabled: true
+    allowSearch: true
+    allowDirectVideoIds: true
+    allowDirectPlaylistIds: true
+    clients:
+      - MUSIC
+      - TV
+      - WEB
+      - ANDROID_VR
+    oauth:
+      enabled: true
+      refreshToken: "${YOUTUBE_OAUTH_REFRESH_TOKEN}"
 
 logging:
   level:


### PR DESCRIPTION
## Summary
- Deezer ARL 쿠키 필수 + Spotify 프리미엄 필수로 무료 대안 불가
- YouTube 플러그인 + OAuth 인증으로 복원
- LavaSrc/Spotify/Deezer 관련 설정 전체 제거

## 서버 배포 후 필요 작업
1. Lavalink 컨테이너 재생성 (LavaSrc JAR 삭제 필요)
2. Lavalink 로그에서 YouTube OAuth device code 확인
3. https://www.google.com/device 에서 코드 입력하여 인증
4. refresh token을 .env.prod에 저장

🤖 Generated with [Claude Code](https://claude.com/claude-code)