### PR TITLE
feat: nginx 리버스 프록시 + certbot SSL 인증 구성

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -29,8 +29,8 @@ DISCORD_CLIENT_ID=your_discord_client_id
 DISCORD_CLIENT_SECRET=your_discord_client_secret
 DISCORD_COMMAND_PREFIX=!
 
-# ⚠ 아래 URL을 실제 서버 IP로 변경하세요
-DISCORD_CALLBACK_URL=http://YOUR_SERVER_IP:3000/auth/discord/callback
+# Discord OAuth 콜백 (도메인 기반 HTTPS)
+DISCORD_CALLBACK_URL=https://api.onyu.dev/auth/discord/callback
 
 # ─── Bot → API 통신 ─────────────────────────────────────
 # Bot과 API 간 내부 통신 인증 키 (임의의 긴 문자열)
@@ -41,13 +41,13 @@ JWT_SECRET=CHANGE_ME_RANDOM_JWT_SECRET
 
 # ─── Web Dashboard ────────────────────────────────────────
 # API CORS origin (웹 대시보드 공개 URL)
-WEB_URL=http://YOUR_SERVER_IP:4000
+WEB_URL=https://onyu.dev
 
 # 웹 → API 내부 통신 (Docker 내부 DNS, 변경 불필요)
 API_INTERNAL_URL=http://api:3000
 
 # OAuth 로그인 리다이렉트용 (브라우저가 접근하는 공개 API URL)
-NEXT_PUBLIC_API_URL=http://YOUR_SERVER_IP:3000
+NEXT_PUBLIC_API_URL=https://api.onyu.dev
 
 # ─── Gemini API ───────────────────────────────────────────
 GEMINI_API_KEY=your_gemini_api_key

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,15 +128,20 @@ jobs:
             # 3. 새 컨테이너로 교체
             $DC up -d --force-recreate api bot web
 
-            # 4. 헬스체크 함수 (최대 60초 대기)
+            # 4. nginx 리로드 (설정 파일 변경 반영, 컨테이너 없으면 시작)
+            $DC up -d nginx
+            $DC exec nginx nginx -s reload 2>/dev/null || true
+
+            # 5. 헬스체크 함수 (최대 60초 대기, 컨테이너 내부 직접 체크)
             healthcheck() {
               local name=$1
-              local port=$2
+              local container=$2
+              local port=$3
               local retries=15
               local wait=4
 
               for i in $(seq 1 $retries); do
-                if curl -sf -o /dev/null --max-time 5 "http://localhost:${port}"; then
+                if docker exec "$container" wget -qO- --timeout=5 "http://localhost:${port}" > /dev/null 2>&1; then
                   echo "=== $name health OK (attempt $i) ==="
                   return 0
                 fi
@@ -147,35 +152,36 @@ jobs:
               return 1
             }
 
-            # 5. 롤백 함수
+            # 6. 롤백 함수
             rollback() {
               echo "!!! 롤백 시작 !!!"
               docker tag "${API_IMG}:prev" "${API_IMG}:latest"
               docker tag "${BOT_IMG}:prev" "${BOT_IMG}:latest"
               docker tag "${WEB_IMG}:prev" "${WEB_IMG}:latest"
               $DC up -d api bot web
+              $DC exec nginx nginx -s reload 2>/dev/null || true
               echo "!!! 이전 버전으로 롤백 완료 !!!"
             }
 
-            # 6. API 헬스체크
-            if ! healthcheck "API" 3000; then
+            # 7. API 헬스체크 (컨테이너 내부에서 직접 체크)
+            if ! healthcheck "API" "onyu-api-prod" 3000; then
               echo "!!! API 헬스체크 실패 !!!"
               rollback
               exit 1
             fi
 
-            # 7. Web 헬스체크
-            if ! healthcheck "WEB" 4000; then
+            # 8. Web 헬스체크 (컨테이너 내부에서 직접 체크)
+            if ! healthcheck "WEB" "onyu-web-prod" 4000; then
               echo "!!! Web 헬스체크 실패 !!!"
               rollback
               exit 1
             fi
 
-            # 8. 헬스체크 통과 후 DB 마이그레이션
+            # 9. 헬스체크 통과 후 DB 마이그레이션
             echo "=== DB 마이그레이션 시작 ==="
             $DC exec api pnpm exec typeorm migration:run -d dist/apps/api/src/data-source.js
 
-            # 9. 모니터링 볼륨 생성 (없으면 생성, 있으면 무시) 및 스택 재시작
+            # 10. 모니터링 볼륨 생성 (없으면 생성, 있으면 무시) 및 스택 재시작
             echo "=== 모니터링 스택 재시작 ==="
             for vol in prometheus_data_prod grafana_data_prod loki_data_prod; do
               docker volume create "nestjs-dhyunbot_${vol}" 2>/dev/null || true
@@ -185,6 +191,9 @@ jobs:
             echo "=== 모니터링 컨테이너 상태 ==="
             $DC ps prometheus grafana loki promtail alertmanager node-exporter postgres-exporter redis-exporter 2>&1 || true
 
-            # 10. 사용하지 않는 이미지 정리 (:prev 유지)
+            # 11. nginx/certbot 최신화
+            $DC up -d nginx certbot
+
+            # 12. 사용하지 않는 이미지 정리 (:prev 유지)
             docker image prune -f
             echo "=== 배포 완료 ==="

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,9 +1,42 @@
 services:
+  # ─── Reverse Proxy ──────────────────────────────────────────
+  nginx:
+    image: nginx:alpine
+    container_name: nginx-prod
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./infra/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./infra/nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./infra/nginx/snippets:/etc/nginx/snippets:ro
+      - certbot_www:/var/www/certbot:ro
+      - certbot_conf:/etc/letsencrypt:ro
+    depends_on:
+      api:
+        condition: service_started
+      web:
+        condition: service_started
+      grafana:
+        condition: service_started
+    restart: unless-stopped
+
+  certbot:
+    image: certbot/certbot
+    container_name: certbot-prod
+    volumes:
+      - certbot_www:/var/www/certbot
+      - certbot_conf:/etc/letsencrypt
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew --webroot --webroot-path=/var/www/certbot; sleep 12h & wait $${!}; done;'"
+    restart: unless-stopped
+
+  # ─── Application ────────────────────────────────────────────
   api:
     container_name: onyu-api-prod
     image: ghcr.io/sambart/onyu/api:latest
-    ports:
-      - "3000:3000"
+    # ports: nginx 리버스 프록시를 통해 접근 — 외부 노출 불필요
+    expose:
+      - "3000"
     env_file:
       - .env.prod
     environment:
@@ -35,8 +68,9 @@ services:
   web:
     container_name: onyu-web-prod
     image: ghcr.io/sambart/onyu/web:latest
-    ports:
-      - "4000:4000"
+    # ports: nginx 리버스 프록시를 통해 접근 — 외부 노출 불필요
+    expose:
+      - "4000"
     env_file:
       - .env.prod
     environment:
@@ -110,12 +144,13 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: grafana-prod
-    ports:
-      - "3002:3000"
+    # ports: nginx 리버스 프록시를 통해 접근 — 외부 노출 불필요
+    expose:
+      - "3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER}
       - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}
-      - GF_SERVER_ROOT_URL=http://${SERVER_HOST}:3002
+      - GF_SERVER_ROOT_URL=https://monitoring.onyu.dev
       - GF_UNIFIED_ALERTING_ENABLED=true
       - GF_ALERTING_ENABLED=false
       - DISCORD_ALERT_WEBHOOK_URL=${DISCORD_ALERT_WEBHOOK_URL}
@@ -220,3 +255,5 @@ volumes:
   loki_data_prod:
     external: true
     name: nestjs-dhyunbot_loki_data_prod
+  certbot_www:
+  certbot_conf:

--- a/infra/certbot/init-letsencrypt.sh
+++ b/infra/certbot/init-letsencrypt.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# ============================================================
+# Let's Encrypt 초기 인증서 발급 스크립트
+# 사용법: chmod +x init-letsencrypt.sh && ./init-letsencrypt.sh
+# ============================================================
+
+set -e
+
+DOMAINS=(onyu.dev www.onyu.dev api.onyu.dev monitoring.onyu.dev)
+EMAIL="dhyun.dev@gmail.com"  # Let's Encrypt 알림 이메일
+STAGING=0  # 테스트 시 1로 변경 (rate limit 회피)
+
+COMPOSE_FILE="docker-compose.prod.yml"
+DATA_PATH="./certbot"
+
+echo "### 인증서 발급 시작 ###"
+
+# nginx가 실행 중인지 확인
+if ! docker compose -f $COMPOSE_FILE ps nginx | grep -q "running"; then
+    echo "nginx 컨테이너를 먼저 시작합니다..."
+    docker compose -f $COMPOSE_FILE up -d nginx
+    sleep 5
+fi
+
+# certbot으로 인증서 발급
+DOMAIN_ARGS=""
+for domain in "${DOMAINS[@]}"; do
+    DOMAIN_ARGS="$DOMAIN_ARGS -d $domain"
+done
+
+STAGING_ARG=""
+if [ $STAGING -eq 1 ]; then
+    STAGING_ARG="--staging"
+fi
+
+docker compose -f $COMPOSE_FILE run --rm certbot certonly \
+    --webroot \
+    --webroot-path=/var/www/certbot \
+    $STAGING_ARG \
+    --email $EMAIL \
+    --agree-tos \
+    --no-eff-email \
+    --force-renewal \
+    $DOMAIN_ARGS
+
+echo ""
+echo "### 인증서 발급 완료! ###"
+echo ""
+echo "다음 단계:"
+echo "1. SSL 설정 활성화:"
+echo "   cp infra/nginx/conf.d/default.ssl.conf infra/nginx/conf.d/default.conf"
+echo ""
+echo "2. ssl-params.conf 주석 해제:"
+echo "   vi infra/nginx/snippets/ssl-params.conf"
+echo ""
+echo "3. .env.prod URL을 HTTPS로 변경"
+echo ""
+echo "4. nginx 리로드:"
+echo "   docker compose -f $COMPOSE_FILE exec nginx nginx -s reload"

--- a/infra/nginx/conf.d/default.conf
+++ b/infra/nginx/conf.d/default.conf
@@ -1,0 +1,79 @@
+# ============================================================
+# Phase 1: HTTP only + ACME challenge (certbot 인증서 발급용)
+# 인증서 발급 후 Phase 2로 교체
+# ============================================================
+
+# ─── www → onyu.dev 리다이렉트 ─────────────────────────────
+server {
+    listen 80;
+    server_name www.onyu.dev;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 http://onyu.dev$request_uri;
+    }
+}
+
+# ─── onyu.dev → Web Dashboard (port 4000) ──────────────────
+server {
+    listen 80;
+    server_name onyu.dev;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        proxy_pass http://web:4000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+# ─── api.onyu.dev → API (port 3000) ────────────────────────
+server {
+    listen 80;
+    server_name api.onyu.dev;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        proxy_pass http://api:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+# ─── monitoring.onyu.dev → Grafana (port 3000 internal) ────
+server {
+    listen 80;
+    server_name monitoring.onyu.dev;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        proxy_pass http://grafana:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/infra/nginx/conf.d/default.ssl.conf
+++ b/infra/nginx/conf.d/default.ssl.conf
@@ -1,0 +1,93 @@
+# ============================================================
+# Phase 2: HTTPS 활성화 (certbot 인증서 발급 완료 후 교체)
+# default.conf를 이 파일로 교체:
+#   cp default.ssl.conf default.conf
+#   docker compose -f docker-compose.prod.yml exec nginx nginx -s reload
+# ============================================================
+
+# ─── HTTP → HTTPS 리다이렉트 (전체 도메인) ─────────────────
+server {
+    listen 80;
+    server_name onyu.dev www.onyu.dev api.onyu.dev monitoring.onyu.dev;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# ─── www → onyu.dev 리다이렉트 (HTTPS) ─────────────────────
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name www.onyu.dev;
+
+    ssl_certificate /etc/letsencrypt/live/onyu.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/onyu.dev/privkey.pem;
+
+    return 301 https://onyu.dev$request_uri;
+}
+
+# ─── onyu.dev → Web Dashboard (port 4000) ──────────────────
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name onyu.dev;
+
+    ssl_certificate /etc/letsencrypt/live/onyu.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/onyu.dev/privkey.pem;
+
+    location / {
+        proxy_pass http://web:4000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+# ─── api.onyu.dev → API (port 3000) ────────────────────────
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name api.onyu.dev;
+
+    ssl_certificate /etc/letsencrypt/live/onyu.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/onyu.dev/privkey.pem;
+
+    location / {
+        proxy_pass http://api:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+# ─── monitoring.onyu.dev → Grafana (port 3000 internal) ────
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name monitoring.onyu.dev;
+
+    ssl_certificate /etc/letsencrypt/live/onyu.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/onyu.dev/privkey.pem;
+
+    location / {
+        proxy_pass http://grafana:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -1,0 +1,41 @@
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+
+    sendfile on;
+    tcp_nopush on;
+    keepalive_timeout 65;
+    client_max_body_size 10m;
+
+    # gzip
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # SSL snippets
+    include /etc/nginx/snippets/ssl-params.conf;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/infra/nginx/snippets/ssl-params.conf
+++ b/infra/nginx/snippets/ssl-params.conf
@@ -1,0 +1,9 @@
+# SSL 공통 파라미터 — certbot 인증서 발급 후 활성화
+# ssl_protocols TLSv1.2 TLSv1.3;
+# ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+# ssl_prefer_server_ciphers off;
+# ssl_session_cache shared:SSL:10m;
+# ssl_session_timeout 1d;
+# ssl_session_tickets off;
+# ssl_stapling on;
+# ssl_stapling_verify on;


### PR DESCRIPTION
## Summary
- nginx 리버스 프록시 추가 (onyu.dev → Web, api.onyu.dev → API, monitoring.onyu.dev → Grafana, www.onyu.dev → 301 redirect)
- certbot 컨테이너로 Let's Encrypt SSL 인증서 자동 발급/갱신
- api/web/grafana 외부 포트 노출 제거 → nginx를 통한 80/443 단일 진입점

## Test plan
- [ ] api.onyu.dev A 레코드 DNS 등록 확인
- [ ] HTTP 모드로 서비스 기동 후 certbot 인증서 발급
- [ ] SSL 설정 활성화 후 HTTPS 접근 확인
- [ ] Discord OAuth 콜백 URL 변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)