### PR TITLE
fix: init-letsencrypt.sh --env-file 누락 수정

### DIFF
--- a/infra/certbot/init-letsencrypt.sh
+++ b/infra/certbot/init-letsencrypt.sh
@@ -11,14 +11,15 @@ EMAIL="dhyun.dev@gmail.com"  # Let's Encrypt 알림 이메일
 STAGING=0  # 테스트 시 1로 변경 (rate limit 회피)
 
 COMPOSE_FILE="docker-compose.prod.yml"
-DATA_PATH="./certbot"
+ENV_FILE=".env.prod"
+DC="docker compose --env-file $ENV_FILE -f $COMPOSE_FILE"
 
 echo "### 인증서 발급 시작 ###"
 
 # nginx가 실행 중인지 확인
-if ! docker compose -f $COMPOSE_FILE ps nginx | grep -q "running"; then
+if ! $DC ps nginx | grep -q "running"; then
     echo "nginx 컨테이너를 먼저 시작합니다..."
-    docker compose -f $COMPOSE_FILE up -d nginx
+    $DC up -d nginx
     sleep 5
 fi
 
@@ -33,7 +34,7 @@ if [ $STAGING -eq 1 ]; then
     STAGING_ARG="--staging"
 fi
 
-docker compose -f $COMPOSE_FILE run --rm certbot certonly \
+$DC run --rm certbot certonly \
     --webroot \
     --webroot-path=/var/www/certbot \
     $STAGING_ARG \
@@ -56,4 +57,4 @@ echo ""
 echo "3. .env.prod URL을 HTTPS로 변경"
 echo ""
 echo "4. nginx 리로드:"
-echo "   docker compose -f $COMPOSE_FILE exec nginx nginx -s reload"
+echo "   $DC exec nginx nginx -s reload"


### PR DESCRIPTION
## Summary
- certbot 초기화 스크립트에서 `--env-file .env.prod` 누락으로 환경변수 미로딩 → Redis healthcheck 실패
- 모든 docker compose 명령에 `--env-file .env.prod` 추가

## Test plan
- [ ] 서버에서 `bash infra/certbot/init-letsencrypt.sh` 실행 시 환경변수 경고 없이 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)