### PR TITLE
fix: YouTube 클라이언트 TVHTML5_SIMPLY/MWEB로 교체

### DIFF
--- a/lavalink/application.yml
+++ b/lavalink/application.yml
@@ -25,9 +25,9 @@ plugins:
     allowDirectPlaylistIds: true
     clients:
       - MUSIC
-      - TV
+      - TVHTML5_SIMPLY
       - WEB
-      - ANDROID_VR
+      - MWEB
     oauth:
       enabled: true
       refreshToken: "${YOUTUBE_OAUTH_REFRESH_TOKEN}"


### PR DESCRIPTION
TV/ANDROID_VR 불안정 → TVHTML5_SIMPLY/MWEB 교체