### PR TITLE
chore: 음악 기능 일시 중단 — 웹 배너 추가, docker lavalink 제거

### DIFF
--- a/apps/web/app/settings/guild/[guildId]/music/page.tsx
+++ b/apps/web/app/settings/guild/[guildId]/music/page.tsx
@@ -331,6 +331,20 @@ export default function MusicSettingsPage() {
         </button>
       </div>
 
+      {/* 일시 중단 안내 배너 */}
+      <section className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6">
+        <div className="flex items-start space-x-3">
+          <span className="text-amber-500 text-lg flex-shrink-0">&#9888;</span>
+          <div>
+            <p className="text-sm font-semibold text-amber-800">음악 기능 일시 중단</p>
+            <p className="text-xs text-amber-700 mt-1">
+              YouTube API 정책 변경으로 인해 음악 재생 기능이 일시 중단되었습니다. 복구 시점은
+              미정이며, 아래 설정은 저장은 가능하지만 실제 재생에는 반영되지 않습니다.
+            </p>
+          </div>
+        </div>
+      </section>
+
       {/* 섹션 1: 기본 설정 */}
       <section className="bg-white rounded-xl border border-gray-200 p-6 mb-6">
         <h2 className="text-base font-semibold text-gray-900 mb-4">{t('music.basicSettings')}</h2>

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,8 +30,6 @@ services:
       - .env
     environment:
       - API_BASE_URL=http://api:3000
-      - LAVALINK_URL=${LAVALINK_URL:-lavalink:2333}
-      - LAVALINK_PASSWORD=${LAVALINK_PASSWORD:-youshallnotpass}
     volumes:
       - .:/workspace
       - root_node_modules:/workspace/node_modules
@@ -39,7 +37,6 @@ services:
     working_dir: /workspace/apps/bot
     depends_on:
       - api
-      - lavalink
     restart: unless-stopped
 
   web:
@@ -66,17 +63,19 @@ services:
       - api
     restart: unless-stopped
 
-  lavalink:
-    container_name: lavalink
-    image: ghcr.io/lavalink-devs/lavalink:4
-    ports:
-      - "2333:2333"
-    volumes:
-      - ./lavalink/application.yml:/opt/Lavalink/application.yml
-    environment:
-      - _JAVA_OPTIONS=-Xmx128m
-      - YOUTUBE_OAUTH_REFRESH_TOKEN=${YOUTUBE_OAUTH_REFRESH_TOKEN:-}
-    restart: unless-stopped
+  # lavalink: 음악 기능 일시 중단 (YouTube API 정책 변경)
+  # 복구 시 주석 해제
+  # lavalink:
+  #   container_name: lavalink
+  #   image: ghcr.io/lavalink-devs/lavalink:4
+  #   ports:
+  #     - "2333:2333"
+  #   volumes:
+  #     - ./lavalink/application.yml:/opt/Lavalink/application.yml
+  #   environment:
+  #     - _JAVA_OPTIONS=-Xmx128m
+  #     - YOUTUBE_OAUTH_REFRESH_TOKEN=${YOUTUBE_OAUTH_REFRESH_TOKEN:-}
+  #   restart: unless-stopped
 
   db:
     image: postgres:15

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -56,12 +56,8 @@ services:
     environment:
       - NODE_ENV=production
       - API_BASE_URL=http://api:3000
-      - LAVALINK_URL=lavalink:2333
-      - LAVALINK_PASSWORD=${LAVALINK_PASSWORD:-youshallnotpass}
     depends_on:
       api:
-        condition: service_started
-      lavalink:
         condition: service_started
     restart: unless-stopped
 
@@ -80,15 +76,17 @@ services:
         condition: service_started
     restart: unless-stopped
 
-  lavalink:
-    container_name: lavalink-prod
-    image: ghcr.io/lavalink-devs/lavalink:4
-    volumes:
-      - ./lavalink/application.yml:/opt/Lavalink/application.yml
-    environment:
-      - _JAVA_OPTIONS=-Xmx128m
-      - YOUTUBE_OAUTH_REFRESH_TOKEN=${YOUTUBE_OAUTH_REFRESH_TOKEN:-}
-    restart: unless-stopped
+  # lavalink: 음악 기능 일시 중단 (YouTube API 정책 변경)
+  # 복구 시 주석 해제
+  # lavalink:
+  #   container_name: lavalink-prod
+  #   image: ghcr.io/lavalink-devs/lavalink:4
+  #   volumes:
+  #     - ./lavalink/application.yml:/opt/Lavalink/application.yml
+  #   environment:
+  #     - _JAVA_OPTIONS=-Xmx128m
+  #     - YOUTUBE_OAUTH_REFRESH_TOKEN=${YOUTUBE_OAUTH_REFRESH_TOKEN:-}
+  #   restart: unless-stopped
 
   db:
     image: postgres:15


### PR DESCRIPTION
## Summary
- 웹 음악 설정 페이지에 일시 중단 안내 배너 추가
- prod/dev docker-compose에서 lavalink 서비스 주석 처리
- bot의 lavalink depends_on 및 환경변수 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)