### PR TITLE
fix: nginx SSL 설정 파일 위치 수정

### DIFF
--- a/infra/nginx/default.ssl.conf
+++ b/infra/nginx/default.ssl.conf
@@ -1,8 +1,8 @@
 # ============================================================
 # Phase 2: HTTPS 활성화 (certbot 인증서 발급 완료 후 교체)
 # default.conf를 이 파일로 교체:
-#   cp default.ssl.conf default.conf
-#   docker compose -f docker-compose.prod.yml exec nginx nginx -s reload
+#   cp infra/nginx/default.ssl.conf infra/nginx/conf.d/default.conf
+#   docker compose --env-file .env.prod -f docker-compose.prod.yml exec nginx nginx -s reload
 # ============================================================
 
 # ─── HTTP → HTTPS 리다이렉트 (전체 도메인) ─────────────────


### PR DESCRIPTION
## Summary
- `default.ssl.conf`를 `conf.d/` 밖으로 이동 → nginx가 인증서 없이 SSL 설정 로드하여 시작 실패하는 문제 해결
- `init-letsencrypt.sh` entrypoint 오버라이드 수정 포함

## Test plan
- [ ] nginx 컨테이너 정상 시작 확인
- [ ] certbot 인증서 발급 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)