### PR TITLE
fix: /me 순위 집계 off-by-one 핫픽스 (16일 → 15일)

### DIFF
--- a/apps/api/src/channel/voice/application/me-profile.service.ts
+++ b/apps/api/src/channel/voice/application/me-profile.service.ts
@@ -268,7 +268,7 @@ export class MeProfileService {
   private getDateRange(days: number): { start: string; end: string } {
     const end = new Date();
     const start = new Date();
-    start.setDate(start.getDate() - days);
+    start.setDate(start.getDate() - (days - 1));
     return { start: this.formatDate(start), end: this.formatDate(end) };
   }
 


### PR DESCRIPTION
## Summary

- `/me` 명령어가 라벨로는 "최근 15일"을 표시하지만 실제 SQL은 16일치를 집계하던 off-by-one 버그 수정.
- `MeProfileService.getDateRange(days)`가 `start = 오늘 - days`로 계산해 SQL `BETWEEN start AND end`(양끝 inclusive)가 `days + 1`일을 포함하던 문제.
- `days - 1`로 빼서 정확히 `days`일치 범위가 되도록 수정.

## 영향 범위

- 순위, 총 음성 시간, 활동 일수, 마이크 사용률, 혼자 있던 시간 → 16일치 → **15일치**로 정정
- 일별 차트는 별도 루프로 이미 15일이라 SQL과 차트 매핑이 1:1로 정합화됨

## Test plan

- [x] `me-profile.service.spec.ts` 단위 테스트 통과
- [ ] 운영 배포 후 `/me` 호출하여 순위/표기 일치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)