### PR TITLE
fix: nginx HTTPS Phase 2 설정 복원

### DIFF
--- a/infra/nginx/conf.d/default.conf
+++ b/infra/nginx/conf.d/default.conf
@@ -1,30 +1,42 @@
 # ============================================================
-# Phase 1: HTTP only + ACME challenge (certbot 인증서 발급용)
-# 인증서 발급 후 Phase 2로 교체
+# Phase 2: HTTPS 활성화 (certbot 인증서 발급 완료 후 교체)
+# 원본: infra/nginx/default.ssl.conf
 # ============================================================
 
-# ─── www → onyu.dev 리다이렉트 ─────────────────────────────
+# ─── HTTP → HTTPS 리다이렉트 (전체 도메인) ─────────────────
 server {
     listen 80;
-    server_name www.onyu.dev;
+    server_name onyu.dev www.onyu.dev api.onyu.dev monitoring.onyu.dev;
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }
 
     location / {
-        return 301 http://onyu.dev$request_uri;
+        return 301 https://$host$request_uri;
     }
+}
+
+# ─── www → onyu.dev 리다이렉트 (HTTPS) ─────────────────────
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name www.onyu.dev;
+
+    ssl_certificate /etc/letsencrypt/live/onyu.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/onyu.dev/privkey.pem;
+
+    return 301 https://onyu.dev$request_uri;
 }
 
 # ─── onyu.dev → Web Dashboard (port 4000) ──────────────────
 server {
-    listen 80;
+    listen 443 ssl;
+    http2 on;
     server_name onyu.dev;
 
-    location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
-    }
+    ssl_certificate /etc/letsencrypt/live/onyu.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/onyu.dev/privkey.pem;
 
     location / {
         proxy_pass http://web:4000;
@@ -40,12 +52,12 @@ server {
 
 # ─── api.onyu.dev → API (port 3000) ────────────────────────
 server {
-    listen 80;
+    listen 443 ssl;
+    http2 on;
     server_name api.onyu.dev;
 
-    location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
-    }
+    ssl_certificate /etc/letsencrypt/live/onyu.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/onyu.dev/privkey.pem;
 
     location / {
         proxy_pass http://api:3000;
@@ -59,12 +71,12 @@ server {
 
 # ─── monitoring.onyu.dev → Grafana (port 3000 internal) ────
 server {
-    listen 80;
+    listen 443 ssl;
+    http2 on;
     server_name monitoring.onyu.dev;
 
-    location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
-    }
+    ssl_certificate /etc/letsencrypt/live/onyu.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/onyu.dev/privkey.pem;
 
     location / {
         proxy_pass http://grafana:3000;


### PR DESCRIPTION
## 배경 (장애 보고)

오늘 새벽 03:36(UTC) 경 nginx 컨테이너 재시작 후 `https://onyu.dev` 등 모든 HTTPS 엔드포인트가 `Connection refused`로 다운.

진단 결과:
- nginx 컨테이너 내부에서 **80 포트만 listen**, 443은 listen 안 함
- 호스트 측 443 매핑은 정상 (`docker port`)
- `infra/nginx/conf.d/default.conf`가 **Phase 1 (HTTP only)** 상태로 git에 커밋되어 있어서, 재시작 시 디스크의 Phase 1 conf가 로드됨
- 그동안은 누군가 운영서버에서 직접 수정한 Phase 2 conf가 nginx 메모리에만 떠 있다가 재시작으로 사라진 상황

## 변경

- `infra/nginx/conf.d/default.conf` ← `infra/nginx/default.ssl.conf` 내용 반영
- 4개 도메인(`onyu.dev`, `www.onyu.dev`, `api.onyu.dev`, `monitoring.onyu.dev`)에 `listen 443 ssl` + `http2 on`
- HTTP 요청 전체를 `https://$host$request_uri`로 301 리다이렉트
- `www.onyu.dev`는 apex로 한 번 더 리다이렉트
- 인증서는 기존 SAN cert(`/etc/letsencrypt/live/onyu.dev/fullchain.pem`)를 4개 도메인 모두 공유 (이미 발급되어 있고 만료까지 56일)

## 사전 검증

- [x] `docker exec certbot-prod certbot certificates`로 SAN에 4개 도메인 모두 포함 확인
- [x] `infra/nginx/snippets/ssl-params.conf` git에 트래킹 확인
- [x] `infra/nginx/default.ssl.conf` 와 동일한 내용 (헤더 주석만 갱신)

## 배포 후 확인

```bash
curl -I https://onyu.dev
curl -I https://api.onyu.dev
curl -I https://monitoring.onyu.dev
curl -I https://www.onyu.dev    # 301 to https://onyu.dev
docker exec nginx-prod sh -c 'ss -tlnp' | grep 443
```

## 재발 방지

이번 사고는 운영서버 conf와 git이 갈려 있었기 때문. 향후 nginx conf 변경은 반드시 git을 통해서만 하도록 운영 룰 합의 필요.