### PR TITLE
fix: CoPresenceModule 순환 참조 부팅 실패 해소

### DIFF
--- a/apps/api/src/channel/voice/co-presence/co-presence.module.ts
+++ b/apps/api/src/channel/voice/co-presence/co-presence.module.ts
@@ -31,7 +31,8 @@ import { GuildCoPresenceConfigController } from './presentation/guild-co-presenc
       VoiceCoPresencePairDailyOrm,
       GuildCoPresenceConfigOrm,
     ]),
-    VoiceChannelModule,
+    // VoiceChannelModule ↔ VoiceAnalyticsModule ↔ CoPresenceModule 순환 — forwardRef로 해소
+    forwardRef(() => VoiceChannelModule),
     UserPrivacyModule,
     CanvasModule,
     GuildMemberModule,


### PR DESCRIPTION
## 문제

PR #70 머지 후 API가 부팅 시 다음 에러로 기동 실패:

```
Nest cannot create the CoPresenceModule instance.
The module at index [1] of the CoPresenceModule "imports" array is undefined.
Scope [AppModule -> VoiceChannelModule -> VoiceAnalyticsModule]
```

## 원인

주간 리포트 친밀도 통합으로 `VoiceAnalyticsModule → CoPresenceModule` 의존이 추가되면서 다음 순환이 형성됨:

```
VoiceChannelModule → VoiceAnalyticsModule → CoPresenceModule → VoiceChannelModule
```

`CoPresenceModule`이 `VoiceChannelModule`을 **직접**(forwardRef 없이) import해, 로딩 시점에 `VoiceChannelModule`이 아직 정의되지 않아 `undefined`로 평가됨.

## 수정

`CoPresenceModule`의 `VoiceChannelModule` import를 `forwardRef(() => VoiceChannelModule)`로 감쌌다. 나머지 순환 지점(`VoiceChannelModule ↔ VoiceAnalyticsModule`, `VoiceAnalyticsModule ↔ CoPresenceModule`)은 이미 forwardRef 적용됨.

## 검증

- 로컬 dev에서 API 정상 부팅 확인 (`GET /health` → HTTP 200)
- 빌드/lint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)